### PR TITLE
Skill Rating & Review System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`ratings.json` schema + build merge — foundation of the Skill Rating & Review System (issue #7, Phase 1+4 of the design in `docs/plan.md`).** New `ratings.json` at the repo root is the static source of truth for per-skill ratings; the file is keyed by `<pluginName>/<skillName>` and each entry is `{ avg: number, count: number, reviews: { stars, body, author, date }[] }`. `scripts/lib/types.ts` gains `Review` and `Rating` interfaces and `Skill.rating?: Rating`; `assets/src/types.ts` mirrors the same shape for the web UI so future PRs can render the badge without a type round-trip. The build merge lives in `scripts/lib/merge-ratings.ts` (pure, fail-soft) and is wired into `scripts/build-index.ts` after bundle membership is attached: it only merges onto **local-marketplace** skills (`source.owner === LOCAL_OWNER && source.repo === LOCAL_REPO`), warns and skips malformed entries instead of throwing, and uses `pluginName/skillName` as the lookup key so two plugins shipping a same-named skill in the same repo don't collide. The test fixture `tests/fixtures/skills_index.json` gains a rating on the `changelog` skill so any web-UI test crossing that card exercises the path where the optional field is present. New unit suite `tests/merge-ratings.test.ts` covers the happy path, the external-skill no-op, the missing-entry no-op, the `pluginName/skillName` disambiguation, the malformed-entry warn-and-skip path, idempotence under double-merge, and the empty-map no-op. `docs/architecture.md` gains a "Ratings & Reviews" section describing the static-data flow (Discussions → ingest workflow → `ratings.json` → build merge → `skills_index.json` → web UI) and explicitly notes that v1 only rates local skills. The UI rendering, `Rating` sort option, and the scheduled ingestion workflow (Phases 2/3/5 of the design) are explicit follow-ups in subsequent PRs — splitting them keeps each diff reviewable.
+
 ## [1.29.1] - 2026-05-18
 
 ### Added

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -19,6 +19,30 @@ export interface Plugin {
   _repo?:         string;
 }
 
+/**
+ * One user-submitted review of a skill, mirroring the server-side `Review`
+ * type in `scripts/lib/types.ts`. The web UI is read-only — reviews are
+ * authored via the linked GitHub Discussions thread, not by client code.
+ */
+export interface Review {
+  stars:  number;
+  body:   string;
+  author: string;
+  date:   string;
+}
+
+/**
+ * Aggregate rating for one skill. `avg` is the mean of `reviews[].stars`,
+ * rounded to one decimal; `count` is `reviews.length`. Optional on `Skill`
+ * because external-marketplace skills are unrated in v1 and the build script
+ * only attaches it for skills with at least one review in `ratings.json`.
+ */
+export interface Rating {
+  avg:     number;
+  count:   number;
+  reviews: Review[];
+}
+
 export interface Skill {
   name:           string;
   pluginName:     string;
@@ -31,6 +55,7 @@ export interface Skill {
   installCommand: string;
   source:         Source;
   bundles?:       string[];
+  rating?:        Rating;
   _repo?:         string;
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -203,6 +203,30 @@ The `category` field is the source of truth for categorisation. The build scans 
 
 This file is committed to the repo (not gitignored) and kept up to date by CI on every push.
 
+## Ratings & Reviews
+
+The marketplace browser surfaces a per-skill star rating and short reviews so users can pick between superficially-similar skills without trying each one. The data flow is intentionally static — no backend, no third-party API at page load, no anonymous form submissions:
+
+```
+GitHub Discussions  →  scripts/ingest-ratings.ts (scheduled)  →  ratings.json (committed)
+ratings.json        →  scripts/build-index.ts (build time)    →  skills_index.json[skills[*].rating]
+skills_index.json   →  assets/src/components/cards/SkillCard.tsx + EntityPanel.tsx (runtime)
+```
+
+1. **Submit** — Users open a "Rate this skill" link from the detail panel that takes them to a per-skill GitHub Discussions thread (one thread per skill, auto-created on first rating). They reply in a structured format (`★★★★☆ — body text…`).
+2. **Ingest** — A scheduled GitHub Action runs `scripts/ingest-ratings.ts` (Phase 5 of the design, not yet shipped). It walks `Ratings: *` threads via `gh api`, parses each reply, applies an anti-spam filter (reviewer must have ≥ 1 public commit), and writes `ratings.json` at the repo root. The file is keyed by `<pluginName>/<skillName>`; the value is `{ avg, count, reviews[] }`.
+3. **Merge** — On every build, `scripts/build-index.ts` reads `ratings.json` and attaches each matching entry to the corresponding skill via the pure-logic helper `scripts/lib/merge-ratings.ts`. Only **local-marketplace** skills (i.e. `source.owner === LOCAL_OWNER && source.repo === LOCAL_REPO`) are merged; external-marketplace skills are unrated in v1 because the Discussions thread lives in this repo. The merge is fail-soft: a missing or malformed `ratings.json` warns but does not deploy-block the site.
+4. **Render** — `SkillCard.tsx` shows a compact `★ 4.3 (12)` badge when `skill.rating` is present; `EntityPanel.tsx` shows the aggregate stars plus individual reviews and a "Rate this skill" link. The `Rating` sort option in `Controls.tsx` orders skills by `avg` descending with `count = 0` last.
+
+The shape lives in two parallel TypeScript modules, kept in sync by review (one file is small, the duplication is intentional — the script-side and web-side type trees do not share imports):
+
+- `scripts/lib/types.ts` defines `Review`, `Rating`, and adds `rating?: Rating` to `Skill`.
+- `assets/src/types.ts` mirrors the same shape for the web UI.
+
+The "skip if not local + skip if malformed" rules are unit-tested in `tests/merge-ratings.test.ts`. The fixture at `tests/fixtures/skills_index.json` carries a rating on the `changelog` skill so any UI test that hits that card exercises the path where the optional field is present.
+
+The phased rollout intentionally lands the data model and the build merge first (this PR) so subsequent UI / sort / ingestion PRs can be reviewed in isolation. See [issue #7](https://github.com/dan323/easier-life-skills/issues/7) for the full plan.
+
 ## How Skills Work
 
 When a skill is installed, the AI agent loads its `SKILL.md` into context whenever it recognises a matching user request. The agent then follows the phases defined in that file, using only the tools listed in the frontmatter.

--- a/ratings.json
+++ b/ratings.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Source of truth for Skill Rating & Review System (issue #7). Keyed by skill triplet 'pluginName/skillName' for local-marketplace skills. The build merges this into skills_index.json; the ingest pipeline (Phase 5) will rewrite this file from Discussions. Until the pipeline ships, this file is hand-maintained and only carries seed/sample entries.",
+  "_schema": {
+    "key": "pluginName/skillName",
+    "value": {
+      "avg": "number — mean of reviews[].stars, rounded to one decimal",
+      "count": "number — reviews.length",
+      "reviews": [
+        {
+          "stars": "1-5",
+          "body": "free-form review text",
+          "author": "github login",
+          "date": "ISO 8601 timestamp"
+        }
+      ]
+    }
+  },
+  "ratings": {}
+}

--- a/scripts/build-index.ts
+++ b/scripts/build-index.ts
@@ -10,6 +10,7 @@ import { fileURLToPath }                          from 'url';
 import { fetchMarketplaceSkills }                 from './lib/fetch-marketplace.js';
 import { generateCatalog, generateCatalogHtml }   from './lib/catalog.js';
 import { refMatchesSkill }                        from './lib/bundle-resolve.js';
+import { mergeRatings, type RatingsFile }         from './lib/merge-ratings.js';
 import type { Agent, Command, MarketplaceEntry, McpServer, Plugin, Skill, Bundle, Hook } from './lib/types.js';
 
 const ROOT         = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -159,6 +160,30 @@ for (const skill of allSkills) {
   }
   skill.bundles = memberships.length > 0 ? memberships : skill.bundles ?? [];
 }
+
+// --- Step 2.5: Merge ratings.json into local-marketplace skills ---
+//
+// See docs/architecture.md → Ratings & Reviews. Pure-logic merge lives in
+// scripts/lib/merge-ratings.ts (unit-tested separately); this block only
+// handles the I/O — reading the file off disk and reporting the count.
+// Fail-soft: a missing or malformed `ratings.json` warns rather than
+// breaking the build, because the file is rewritten by a separate
+// scheduled workflow (Phase 5 of the design) we don't want to deploy-block.
+const ratingsPath = join(ROOT, 'ratings.json');
+let ratingsFile: RatingsFile = {};
+if (existsSync(ratingsPath)) {
+  try {
+    ratingsFile = JSON.parse(readFileSync(ratingsPath, 'utf8')) as RatingsFile;
+  } catch (err) {
+    console.warn(`⚠ ratings.json present but unparseable, skipping: ${(err as Error).message}`);
+  }
+}
+const ratingsResult = mergeRatings(allSkills, ratingsFile.ratings ?? {}, {
+  localOwner: LOCAL_OWNER,
+  localRepo:  LOCAL_REPO,
+});
+console.log(`✓ ratings.json — ${ratingsResult.merged} skill rating(s) merged` +
+  (ratingsResult.skipped > 0 ? ` (${ratingsResult.skipped} skipped)` : ''));
 
 const index = {
   meta: {

--- a/scripts/lib/merge-ratings.ts
+++ b/scripts/lib/merge-ratings.ts
@@ -1,0 +1,72 @@
+/* lib/merge-ratings.ts — merge ratings.json into the list of local-marketplace skills.
+ *
+ * Source of truth for the Skill Rating & Review System (issue #7,
+ * docs/architecture.md → Ratings & Reviews). Keyed by `<pluginName>/<skillName>`,
+ * only local-marketplace skills (`source.owner === localOwner && source.repo === localRepo`)
+ * are merged — external-marketplace skills are intentionally left unrated in v1.
+ *
+ * The merge is fail-soft: a missing or malformed entry warns rather than throwing,
+ * because ratings.json is rewritten by a separate scheduled workflow (Phase 5 of
+ * the design) and we don't want a transient bad write to deploy-block the site.
+ *
+ * Pure function — no I/O, no globals. The build script handles reading the file
+ * and assigning the merged result back; unit tests exercise this in isolation.
+ */
+
+import type { Rating, Skill } from './types.js';
+
+export type RatingsMap = Record<string, Rating>;
+
+export interface RatingsFile {
+  ratings?: RatingsMap;
+}
+
+export interface MergeRatingsOptions {
+  localOwner: string;
+  localRepo: string;
+  warn?: (msg: string) => void;
+}
+
+export interface MergeRatingsResult {
+  merged: number;
+  skipped: number;
+}
+
+/** Type guard for a single Rating entry. */
+function isRating(value: unknown): value is Rating {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  return typeof r['avg'] === 'number'
+      && typeof r['count'] === 'number'
+      && Array.isArray(r['reviews']);
+}
+
+/**
+ * Mutates `skills` in place: assigns `rating` to every local-marketplace skill
+ * whose `<pluginName>/<name>` key appears in `ratings`. Returns counts so the
+ * caller can print a one-line summary.
+ */
+export function mergeRatings(
+  skills: Skill[],
+  ratings: RatingsMap,
+  opts: MergeRatingsOptions,
+): MergeRatingsResult {
+  const warn = opts.warn ?? ((m: string) => console.warn(m));
+  let merged = 0;
+  let skipped = 0;
+  for (const skill of skills) {
+    if (skill.source.owner !== opts.localOwner) continue;
+    if (skill.source.repo  !== opts.localRepo)  continue;
+    const key = `${skill.pluginName}/${skill.name}`;
+    const r = ratings[key];
+    if (r === undefined) continue;
+    if (!isRating(r)) {
+      warn(`⚠ ratings.json entry '${key}' has wrong shape, skipping`);
+      skipped++;
+      continue;
+    }
+    skill.rating = r;
+    merged++;
+  }
+  return { merged, skipped };
+}

--- a/scripts/lib/types.ts
+++ b/scripts/lib/types.ts
@@ -6,6 +6,33 @@ export interface PluginSource {
   repoUrl: string;
 }
 
+/**
+ * One user-submitted review of a skill. The shape mirrors the structured
+ * Discussions reply parsed by `scripts/ingest-ratings.ts` (Phase 5 of the
+ * Skill Rating & Review System, see docs/architecture.md → Ratings &
+ * Reviews). `stars` is 1-5 inclusive; `body` is the free-form review text.
+ */
+export interface Review {
+  stars: number;
+  body: string;
+  /** GitHub login of the reviewer (no email, no other PII). */
+  author: string;
+  /** ISO 8601 timestamp of the original Discussions reply. */
+  date: string;
+}
+
+/**
+ * Aggregate rating for one skill. `avg` is the mean of `reviews[].stars`,
+ * rounded to one decimal; `count` is `reviews.length`. Both are stored even
+ * though they are derivable from `reviews`, so the web UI can render the
+ * badge without scanning the reviews array.
+ */
+export interface Rating {
+  avg: number;
+  count: number;
+  reviews: Review[];
+}
+
 export interface Skill {
   name: string;
   pluginName: string;
@@ -20,6 +47,12 @@ export interface Skill {
   installCommand: string;
   source: PluginSource;
   bundles?: string[];
+  /**
+   * Optional aggregate rating. Present only for local-marketplace skills
+   * that have at least one review in `ratings.json`. External-marketplace
+   * skills do not carry ratings in v1.
+   */
+  rating?: Rating;
   _repo?: string;
 }
 

--- a/tests/fixtures/skills_index.json
+++ b/tests/fixtures/skills_index.json
@@ -74,7 +74,15 @@
       "readOnly": false,
       "rawSkillUrl": "https://raw.githubusercontent.com/dan323/easier-life-skills/master/plugins/docs/skills/changelog/SKILL.md",
       "installCommand": "/plugin install docs@easier-life-skills",
-      "source": { "owner": "dan323", "repo": "easier-life-skills", "repoUrl": "https://github.com/dan323/easier-life-skills" }
+      "source": { "owner": "dan323", "repo": "easier-life-skills", "repoUrl": "https://github.com/dan323/easier-life-skills" },
+      "rating": {
+        "avg": 4.5,
+        "count": 2,
+        "reviews": [
+          { "stars": 5, "body": "Saved me a lot of time on release notes.", "author": "octocat", "date": "2026-05-10T12:00:00Z" },
+          { "stars": 4, "body": "Wish it auto-bumped the version too.", "author": "hubot", "date": "2026-05-12T09:30:00Z" }
+        ]
+      }
     },
     {
       "name": "find-dead-code",

--- a/tests/merge-ratings.test.ts
+++ b/tests/merge-ratings.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for `scripts/lib/merge-ratings.ts` — the pure-logic half of
+ * the Skill Rating & Review System (issue #7).
+ *
+ * The build script's I/O is intentionally not covered here; this suite
+ * exercises only the in-memory merge so we can verify the local-only
+ * scope, the key shape, the fail-soft type guard, and idempotence
+ * without spinning up a fake filesystem.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mergeRatings, type RatingsMap } from '../scripts/lib/merge-ratings.ts';
+import type { Skill } from '../scripts/lib/types.ts';
+
+const LOCAL_OWNER = 'dan323';
+const LOCAL_REPO  = 'easier-life-skills';
+
+function makeSkill(over: Partial<Skill> & Pick<Skill, 'name' | 'pluginName'>): Skill {
+  return {
+    name:           over.name,
+    pluginName:     over.pluginName,
+    version:        over.version ?? '0.0.0',
+    description:    over.description ?? '',
+    category:       over.category ?? null,
+    keywords:       over.keywords ?? [],
+    tools:          over.tools ?? [],
+    readOnly:       over.readOnly ?? false,
+    skillPath:      over.skillPath ?? '',
+    rawSkillUrl:    over.rawSkillUrl ?? '',
+    installCommand: over.installCommand ?? '',
+    source: over.source ?? {
+      owner:   LOCAL_OWNER,
+      repo:    LOCAL_REPO,
+      repoUrl: `https://github.com/${LOCAL_OWNER}/${LOCAL_REPO}`,
+    },
+  };
+}
+
+describe('mergeRatings', () => {
+  it('merges a well-formed rating onto a matching local skill', () => {
+    const skills = [makeSkill({ name: 'changelog', pluginName: 'docs' })];
+    const ratings: RatingsMap = {
+      'docs/changelog': {
+        avg: 4.5,
+        count: 2,
+        reviews: [
+          { stars: 5, body: 'great', author: 'octocat', date: '2026-05-10T00:00:00Z' },
+          { stars: 4, body: 'good',  author: 'hubot',   date: '2026-05-11T00:00:00Z' },
+        ],
+      },
+    };
+
+    const result = mergeRatings(skills, ratings, { localOwner: LOCAL_OWNER, localRepo: LOCAL_REPO });
+
+    expect(result).toEqual({ merged: 1, skipped: 0 });
+    expect(skills[0]!.rating).toEqual(ratings['docs/changelog']);
+  });
+
+  it('does not merge ratings onto external-marketplace skills', () => {
+    const external = makeSkill({
+      name:       'changelog',
+      pluginName: 'docs',
+      source: { owner: 'someone-else', repo: 'their-skills', repoUrl: 'https://github.com/someone-else/their-skills' },
+    });
+    const ratings: RatingsMap = {
+      'docs/changelog': { avg: 5, count: 1, reviews: [] },
+    };
+
+    const result = mergeRatings([external], ratings, { localOwner: LOCAL_OWNER, localRepo: LOCAL_REPO });
+
+    expect(result).toEqual({ merged: 0, skipped: 0 });
+    expect(external.rating).toBeUndefined();
+  });
+
+  it('leaves skills without a matching entry untouched', () => {
+    const skills = [
+      makeSkill({ name: 'changelog',     pluginName: 'docs' }),
+      makeSkill({ name: 'find-dead-code', pluginName: 'code-audit' }),
+    ];
+    const ratings: RatingsMap = {
+      'docs/changelog': { avg: 5, count: 1, reviews: [] },
+    };
+
+    mergeRatings(skills, ratings, { localOwner: LOCAL_OWNER, localRepo: LOCAL_REPO });
+
+    expect(skills[0]!.rating).toBeDefined();
+    expect(skills[1]!.rating).toBeUndefined();
+  });
+
+  it('uses `pluginName/skillName` as the lookup key, not just skillName', () => {
+    // Two same-named skills in different plugins (same repo) get disambiguated.
+    const a = makeSkill({ name: 'sync', pluginName: 'plugin-a' });
+    const b = makeSkill({ name: 'sync', pluginName: 'plugin-b' });
+    const ratings: RatingsMap = {
+      'plugin-a/sync': { avg: 5, count: 1, reviews: [] },
+    };
+
+    mergeRatings([a, b], ratings, { localOwner: LOCAL_OWNER, localRepo: LOCAL_REPO });
+
+    expect(a.rating).toBeDefined();
+    expect(b.rating).toBeUndefined();
+  });
+
+  it('skips a malformed entry with a warning instead of throwing', () => {
+    const skills = [makeSkill({ name: 'changelog', pluginName: 'docs' })];
+    // Cast through unknown so the test can express the "field arrives wrong"
+    // shape without lying to the compiler about the public RatingsMap type.
+    const ratings = {
+      'docs/changelog': { avg: 'four point five', count: 2 },
+    } as unknown as RatingsMap;
+    const warn = vi.fn();
+
+    const result = mergeRatings(skills, ratings, {
+      localOwner: LOCAL_OWNER,
+      localRepo:  LOCAL_REPO,
+      warn,
+    });
+
+    expect(result).toEqual({ merged: 0, skipped: 1 });
+    expect(skills[0]!.rating).toBeUndefined();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]![0]).toMatch(/docs\/changelog/);
+  });
+
+  it('is idempotent when called twice', () => {
+    const skills = [makeSkill({ name: 'changelog', pluginName: 'docs' })];
+    const ratings: RatingsMap = {
+      'docs/changelog': { avg: 4.5, count: 2, reviews: [] },
+    };
+
+    mergeRatings(skills, ratings, { localOwner: LOCAL_OWNER, localRepo: LOCAL_REPO });
+    const after_first = JSON.parse(JSON.stringify(skills[0]));
+    mergeRatings(skills, ratings, { localOwner: LOCAL_OWNER, localRepo: LOCAL_REPO });
+    const after_second = JSON.parse(JSON.stringify(skills[0]));
+
+    expect(after_second).toEqual(after_first);
+  });
+
+  it('treats an empty ratings map as a no-op (no skills tagged)', () => {
+    const skills = [makeSkill({ name: 'changelog', pluginName: 'docs' })];
+
+    const result = mergeRatings(skills, {}, { localOwner: LOCAL_OWNER, localRepo: LOCAL_REPO });
+
+    expect(result).toEqual({ merged: 0, skipped: 0 });
+    expect(skills[0]!.rating).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the **Skill Rating & Review System** (issue #7) — lands the static
data model and the build-time merge so subsequent UI / sort / ingestion PRs
(Phases 2/3/5 of the design in `docs/plan.md`) can be reviewed in isolation.
No UI changes in this PR.

- `ratings.json` at repo root, keyed by `<pluginName>/<skillName>`,
  value `{ avg, count, reviews[] }`. Seeded empty; ingestion in Phase 5
  rewrites it from per-skill Discussions threads.
- `scripts/lib/types.ts` gains `Review` + `Rating` interfaces and
  `Skill.rating?: Rating`. `assets/src/types.ts` mirrors the same shape so
  follow-up rendering PRs do not require a type round-trip.
- `scripts/lib/merge-ratings.ts` is the pure, fail-soft merge function.
  Only merges onto **local-marketplace** skills (external-marketplace
  skills are unrated in v1); skips malformed entries with a warning;
  uses `pluginName/skillName` so two plugins shipping a same-named skill
  in the same repo do not collide.
- `scripts/build-index.ts` reads `ratings.json` after bundle membership
  is attached, calls `mergeRatings`, and prints a one-line summary.
  Missing/unparseable file warns rather than deploy-blocks the site.
- Test fixture gains a rating on the `changelog` skill so any UI test
  crossing that card exercises the optional field.
- New `tests/merge-ratings.test.ts` — 7-case unit suite covering the
  happy path, external-skill no-op, missing-entry no-op,
  `pluginName/skillName` disambiguation, malformed-entry warn-and-skip,
  double-merge idempotence, and empty-map no-op.
- `docs/architecture.md` gains a "Ratings & Reviews" section describing
  the static-data flow and the v1 local-only scope.

Phases 2 (UI rendering — SkillCard badge + EntityPanel reviews),
3 (`Rating` sort option), and 5 (ingestion workflow + script) are
explicit follow-ups — splitting them keeps each diff reviewable.

Refs #7.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 20 UI test files / 100 tests pass, installer 2 files /
      55 tests pass, new `merge-ratings.test.ts` adds 7 tests
- [x] `npm run build` — ratings.json reads cleanly, "✓ ratings.json — 0
      skill rating(s) merged" appears in the build log
- [x] CI green on the PR
- [x] Manually sanity-check that a hand-edited `ratings.json` entry on
      e.g. `docs/changelog` ends up under `skills_index.json#skills[*].rating`
      after `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)