### PR TITLE
feat(web-ui): custom bundle builder

### DIFF
--- a/assets/src/bundle-state.ts
+++ b/assets/src/bundle-state.ts
@@ -1,0 +1,100 @@
+/**
+ * bundle-state.ts — shared types and helpers for the custom bundle builder.
+ *
+ * A BundleItem identifies one card selected by the user. Items are keyed by
+ * a stable `id` = "${kind}/${name}" which is unique per entity. The
+ * `installCommand` is stored separately and is used for install-script
+ * deduplication (multiple skills from the same plugin share one command).
+ */
+
+export type BundleItemKind = 'skill' | 'agent' | 'mcpServer' | 'command' | 'hook' | 'plugin';
+
+export interface BundleItem {
+  /** Stable key — "${kind}/${name}", unique per entity. */
+  id:             string;
+  name:           string;
+  kind:           BundleItemKind;
+  installCommand: string;
+  /** The "owner/repo" string used to group marketplace-add commands. */
+  repo:           string;
+  /** Whether the source is a proper marketplace (vs plugin-only shim). */
+  isMarketplace:  boolean;
+}
+
+/**
+ * Encode a BundleItem to the compact URL token "name|installCommand|repo|kind".
+ * The separator is | which does not appear in Claude plugin command names.
+ */
+export function encodeItem(item: BundleItem): string {
+  return [item.name, item.installCommand, item.repo, item.kind].join('|');
+}
+
+/**
+ * Decode a URL token produced by encodeItem.  Returns null when the token
+ * is malformed so old/corrupt URLs don't crash the app.
+ */
+export function decodeItem(token: string): BundleItem | null {
+  const parts = token.split('|');
+  if (parts.length < 4) return null;
+  const [name, installCommand, repo, kind] = parts;
+  if (!name || !installCommand || !repo || !kind) return null;
+  const validKinds: BundleItemKind[] = ['skill', 'agent', 'mcpServer', 'command', 'hook', 'plugin'];
+  if (!validKinds.includes(kind as BundleItemKind)) return null;
+  return {
+    id:             `${kind}/${name}`,
+    name,
+    kind:           kind as BundleItemKind,
+    installCommand,
+    repo,
+    isMarketplace:  true,   // will be refreshed by App once sources load
+  };
+}
+
+/**
+ * Build the install script for a set of bundle items.
+ *
+ * For marketplace sources the script uses `/plugin install …` commands.
+ * For plugin-only shims the npx installer is referenced in a comment since
+ * the manual path is too involved for a copyable one-liner.
+ *
+ * The script is grouped by repo so that a single
+ * `claude plugin marketplace add` precedes every install from that repo.
+ */
+export function buildInstallScript(
+  items:   BundleItem[],
+  sources: Record<string, { isMarketplace: boolean }> = {},
+): string {
+  if (items.length === 0) return '';
+
+  // Resolve isMarketplace against live sources data
+  const resolved = items.map(item => ({
+    ...item,
+    isMarketplace: sources[item.repo]?.isMarketplace !== false,
+  }));
+
+  const marketplace  = resolved.filter(i => i.isMarketplace);
+  const pluginOnly   = resolved.filter(i => !i.isMarketplace);
+
+  const lines: string[] = [];
+
+  // Deduplicate install commands (same plugin may cover multiple skills)
+  const seen = new Set<string>();
+  for (const item of marketplace) {
+    if (!seen.has(item.installCommand)) {
+      lines.push(item.installCommand);
+      seen.add(item.installCommand);
+    }
+  }
+
+  if (pluginOnly.length > 0) {
+    if (lines.length > 0) lines.push('');
+    const pluginNames = [...new Set(pluginOnly.map(i => i.name))];
+    lines.push(
+      `# The following items come from plugin-only repos — install via npx:`,
+      `# npx @dan323/easier-life-skills --bundle <bundle-name>`,
+      ...pluginNames.map(n => `# (includes: ${n})`),
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/assets/src/bundle-state.ts
+++ b/assets/src/bundle-state.ts
@@ -2,7 +2,8 @@
  * bundle-state.ts — shared types and helpers for the custom bundle builder.
  *
  * A BundleItem identifies one card selected by the user. Items are keyed by
- * a stable `id` = "${kind}/${name}" which is unique per entity. The
+ * a stable `id` = "${kind}/${repo}/${pluginName?}/${name}" which is unique
+ * across marketplaces and plugins. The
  * `installCommand` is stored separately and is used for install-script
  * deduplication (multiple skills from the same plugin share one command).
  */
@@ -10,23 +11,38 @@
 export type BundleItemKind = 'skill' | 'agent' | 'mcpServer' | 'command' | 'hook' | 'plugin';
 
 export interface BundleItem {
-  /** Stable key — "${kind}/${name}", unique per entity. */
+  /** Stable key — "${kind}/${repo}/${pluginName?}/${name}", unique per entity. */
   id:             string;
   name:           string;
   kind:           BundleItemKind;
   installCommand: string;
   /** The "owner/repo" string used to group marketplace-add commands. */
   repo:           string;
+  /** Plugin scope for non-plugin entities (skills/agents/mcp/commands/hooks). */
+  pluginName?:    string;
   /** Whether the source is a proper marketplace (vs plugin-only shim). */
   isMarketplace:  boolean;
 }
 
 /**
- * Encode a BundleItem to the compact URL token "name|installCommand|repo|kind".
+ * Build a stable collision-free bundle ID.
+ */
+export function buildBundleItemId(
+  kind: BundleItemKind,
+  name: string,
+  repo: string,
+  pluginName = '',
+): string {
+  const pluginScope = kind === 'plugin' ? '' : pluginName;
+  return `${kind}/${repo}/${pluginScope}/${name}`;
+}
+
+/**
+ * Encode a BundleItem to the compact URL token "name|installCommand|repo|kind|pluginName".
  * The separator is | which does not appear in Claude plugin command names.
  */
 export function encodeItem(item: BundleItem): string {
-  return [item.name, item.installCommand, item.repo, item.kind].join('|');
+  return [item.name, item.installCommand, item.repo, item.kind, item.pluginName ?? ''].join('|');
 }
 
 /**
@@ -35,17 +51,18 @@ export function encodeItem(item: BundleItem): string {
  */
 export function decodeItem(token: string): BundleItem | null {
   const parts = token.split('|');
-  if (parts.length < 4) return null;
-  const [name, installCommand, repo, kind] = parts;
+  if (parts.length < 4 || parts.length > 5) return null;
+  const [name, installCommand, repo, kind, pluginName = ''] = parts;
   if (!name || !installCommand || !repo || !kind) return null;
   const validKinds: BundleItemKind[] = ['skill', 'agent', 'mcpServer', 'command', 'hook', 'plugin'];
   if (!validKinds.includes(kind as BundleItemKind)) return null;
   return {
-    id:             `${kind}/${name}`,
+    id:             buildBundleItemId(kind as BundleItemKind, name, repo, pluginName),
     name,
     kind:           kind as BundleItemKind,
     installCommand,
     repo,
+    pluginName:     pluginName || undefined,
     isMarketplace:  true,   // will be refreshed by App once sources load
   };
 }

--- a/assets/src/bundle-state.ts
+++ b/assets/src/bundle-state.ts
@@ -70,12 +70,10 @@ export function decodeItem(token: string): BundleItem | null {
 /**
  * Build the install script for a set of bundle items.
  *
- * For marketplace sources the script uses `/plugin install …` commands.
+ * For marketplace sources the script emits deduplicated install commands
+ * (multiple items from the same plugin may share one command).
  * For plugin-only shims the npx installer is referenced in a comment since
  * the manual path is too involved for a copyable one-liner.
- *
- * The script is grouped by repo so that a single
- * `claude plugin marketplace add` precedes every install from that repo.
  */
 export function buildInstallScript(
   items:   BundleItem[],

--- a/assets/src/components/App.tsx
+++ b/assets/src/components/App.tsx
@@ -17,7 +17,7 @@ import { track, getStoredConsent, setStoredConsent } from '../analytics.ts';
 import type { ConsentState } from '../analytics.ts';
 import { ConsentBanner } from './ConsentBanner.tsx';
 import { BUILTIN_REPO } from '../constants.ts';
-import { encodeItem, decodeItem } from '../bundle-state.ts';
+import { encodeItem, decodeItem, buildBundleItemId } from '../bundle-state.ts';
 import type { BundleItem, BundleItemKind } from '../bundle-state.ts';
 import type { Plugin, Skill, Agent, McpServer, Command, Hook, Bundle, SkillsIndexMeta } from '../types.ts';
 
@@ -34,13 +34,15 @@ function makeItem(
   kind: BundleItemKind,
   installCommand: string,
   repo: string,
+  pluginName = '',
 ): BundleItem {
   return {
-    id:             `${kind}/${name}`,
+    id:             buildBundleItemId(kind, name, repo, pluginName),
     name,
     kind,
     installCommand,
     repo,
+    pluginName:     pluginName || undefined,
     isMarketplace:  true,   // refined later by buildInstallScript against live sources
   };
 }
@@ -200,7 +202,7 @@ export function App() {
     });
   };
 
-  // bundledIds maps entity id ("kind/name") → true for O(1) card lookups
+  // bundledIds maps entity id ("kind/repo/plugin?/name") → true for O(1) card lookups
   const bundledIds = useMemo(() => new Set(bundleItems.map(i => i.id)), [bundleItems]);
 
   const handleRemoveFromBundle = (id: string) => {
@@ -255,11 +257,11 @@ export function App() {
           onOpenCommand={e => handleOpenEntity('command', e)}
           onOpenHook={e  => handleOpenEntity('hook',      e)}
           onToggleBundlePlugin={p  => toggleBundle(makeItem(p.name,  'plugin',    p.installCommand, p._repo ?? ''))}
-          onToggleBundleSkill={s   => toggleBundle(makeItem(s.name,  'skill',     s.installCommand, s._repo ?? ''))}
-          onToggleBundleAgent={a   => toggleBundle(makeItem(a.name,  'agent',     a.installCommand, a._repo ?? ''))}
-          onToggleBundleMcp={m     => toggleBundle(makeItem(m.name,  'mcpServer', m.installCommand, m._repo ?? ''))}
-          onToggleBundleCommand={c => toggleBundle(makeItem(c.name,  'command',   c.installCommand, c._repo ?? ''))}
-          onToggleBundleHook={h    => toggleBundle(makeItem(h.name,  'hook',      h.installCommand, h._repo ?? ''))}
+          onToggleBundleSkill={s   => toggleBundle(makeItem(s.name,  'skill',     s.installCommand, s._repo ?? '', s.pluginName))}
+          onToggleBundleAgent={a   => toggleBundle(makeItem(a.name,  'agent',     a.installCommand, a._repo ?? '', a.pluginName))}
+          onToggleBundleMcp={m     => toggleBundle(makeItem(m.name,  'mcpServer', m.installCommand, m._repo ?? '', m.pluginName))}
+          onToggleBundleCommand={c => toggleBundle(makeItem(c.name,  'command',   c.installCommand, c._repo ?? '', c.pluginName))}
+          onToggleBundleHook={h    => toggleBundle(makeItem(h.name,  'hook',      h.installCommand, h._repo ?? '', h.pluginName))}
         />
       </main>
 

--- a/assets/src/components/App.tsx
+++ b/assets/src/components/App.tsx
@@ -10,12 +10,15 @@ import { Grid }           from './Grid.tsx';
 import { PluginPanel }    from './PluginPanel.tsx';
 import { EntityPanel }    from './EntityPanel.tsx';
 import type { EntityKind } from './EntityPanel.tsx';
+import { BundleDrawer }   from './BundleDrawer.tsx';
 import { loadMarketplace } from '../marketplace.ts';
 import { readUrlState, writeUrlState } from '../url-state.ts';
 import { track, getStoredConsent, setStoredConsent } from '../analytics.ts';
 import type { ConsentState } from '../analytics.ts';
 import { ConsentBanner } from './ConsentBanner.tsx';
 import { BUILTIN_REPO } from '../constants.ts';
+import { encodeItem, decodeItem } from '../bundle-state.ts';
+import type { BundleItem, BundleItemKind } from '../bundle-state.ts';
 import type { Plugin, Skill, Agent, McpServer, Command, Hook, Bundle, SkillsIndexMeta } from '../types.ts';
 
 const VALID_VIEWS: ViewKey[] = ['plugins', 'skills', 'agents', 'mcpServers', 'commands', 'hooks', 'bundles'];
@@ -23,6 +26,23 @@ const VALID_VIEWS: ViewKey[] = ['plugins', 'skills', 'agents', 'mcpServers', 'co
 interface OpenEntity {
   kind:   EntityKind;
   entity: Skill | Agent | McpServer | Command | Hook;
+}
+
+/** Build a BundleItem from a card entity. */
+function makeItem(
+  name: string,
+  kind: BundleItemKind,
+  installCommand: string,
+  repo: string,
+): BundleItem {
+  return {
+    id:             `${kind}/${name}`,
+    name,
+    kind,
+    installCommand,
+    repo,
+    isMarketplace:  true,   // refined later by buildInstallScript against live sources
+  };
 }
 
 export function App() {
@@ -34,6 +54,11 @@ export function App() {
   const [activeRepos,      setActiveRepos]      = useState<Set<string>>(new Set(initial.repos));
   const [activeCategories, setActiveCategories] = useState<Set<string>>(new Set(initial.cats));
 
+  // Bundle state: ordered array of selected items, keyed by installCommand
+  const [bundleItems, setBundleItems] = useState<BundleItem[]>(() =>
+    initial.bundle.map(decodeItem).filter((x): x is BundleItem => x !== null)
+  );
+
   const [plugins,    setPlugins]    = useState<Plugin[]>([]);
   const [skills,     setSkills]     = useState<Skill[]>([]);
   const [agents,     setAgents]     = useState<Agent[]>([]);
@@ -44,6 +69,13 @@ export function App() {
   const [sources,    setSources]    = useState<SourceItem[]>([{ repo: BUILTIN_REPO, count: 0, builtin: true }]);
   const [meta,       setMeta]       = useState<SkillsIndexMeta | undefined>(undefined);
   const [loaded,     setLoaded]     = useState(false);
+
+  // Map from "owner/repo" → { isMarketplace } for BundleDrawer
+  const sourcesMap = useMemo<Record<string, { isMarketplace: boolean }>>(() => {
+    const map: Record<string, { isMarketplace: boolean }> = {};
+    for (const s of sources) map[s.repo] = { isMarketplace: !s.builtin || true };
+    return map;
+  }, [sources]);
 
   const [openPlugin, setOpenPlugin] = useState<Plugin | null>(null);
   const [openEntity, setOpenEntity] = useState<OpenEntity | null>(null);
@@ -72,13 +104,15 @@ export function App() {
     return () => { cancelled = true; };
   }, []);
 
+  // Sync all app state → URL hash
   useLayoutEffect(() => {
     writeUrlState({
       view, query: query.toLowerCase(), sort,
-      repos: [...activeRepos],
-      cats:  [...activeCategories],
+      repos:  [...activeRepos],
+      cats:   [...activeCategories],
+      bundle: bundleItems.map(encodeItem),
     });
-  }, [view, query, sort, activeRepos, activeCategories]);
+  }, [view, query, sort, activeRepos, activeCategories, bundleItems]);
 
   useLayoutEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -156,6 +190,25 @@ export function App() {
     setStoredConsent(null);
   };
 
+  // --- Bundle toggle helpers ---
+  const toggleBundle = (item: BundleItem) => {
+    setBundleItems(prev => {
+      if (prev.some(i => i.id === item.id)) {
+        return prev.filter(i => i.id !== item.id);
+      }
+      return [...prev, item];
+    });
+  };
+
+  // bundledIds maps entity id ("kind/name") → true for O(1) card lookups
+  const bundledIds = useMemo(() => new Set(bundleItems.map(i => i.id)), [bundleItems]);
+
+  const handleRemoveFromBundle = (id: string) => {
+    setBundleItems(prev => prev.filter(i => i.id !== id));
+  };
+
+  const handleClearBundle = () => setBundleItems([]);
+
   const lowerQuery = query.toLowerCase();
 
   return (
@@ -194,12 +247,19 @@ export function App() {
           activeCategories={activeCategories}
           data={{ plugins, skills, agents, mcpServers, commands, hooks, bundles }}
           sources={meta?.sources}
+          bundledIds={bundledIds}
           onOpenPlugin={handleOpenPlugin}
           onOpenSkill={e => handleOpenEntity('skill',     e)}
           onOpenAgent={e => handleOpenEntity('agent',     e)}
           onOpenMcp={e   => handleOpenEntity('mcpServer', e)}
           onOpenCommand={e => handleOpenEntity('command', e)}
           onOpenHook={e  => handleOpenEntity('hook',      e)}
+          onToggleBundlePlugin={p  => toggleBundle(makeItem(p.name,  'plugin',    p.installCommand, p._repo ?? ''))}
+          onToggleBundleSkill={s   => toggleBundle(makeItem(s.name,  'skill',     s.installCommand, s._repo ?? ''))}
+          onToggleBundleAgent={a   => toggleBundle(makeItem(a.name,  'agent',     a.installCommand, a._repo ?? ''))}
+          onToggleBundleMcp={m     => toggleBundle(makeItem(m.name,  'mcpServer', m.installCommand, m._repo ?? ''))}
+          onToggleBundleCommand={c => toggleBundle(makeItem(c.name,  'command',   c.installCommand, c._repo ?? ''))}
+          onToggleBundleHook={h    => toggleBundle(makeItem(h.name,  'hook',      h.installCommand, h._repo ?? ''))}
         />
       </main>
 
@@ -225,6 +285,13 @@ export function App() {
         open={openEntity}
         bundles={bundles}
         onClose={() => setOpenEntity(null)}
+      />
+
+      <BundleDrawer
+        items={bundleItems}
+        sources={sourcesMap}
+        onRemove={handleRemoveFromBundle}
+        onClear={handleClearBundle}
       />
 
       <ConsentBanner consent={consent} onChoice={handleConsentChoice} />

--- a/assets/src/components/BundleDrawer.tsx
+++ b/assets/src/components/BundleDrawer.tsx
@@ -24,7 +24,7 @@ export function BundleDrawer({ items, sources, onRemove, onClear }: Props) {
   const script = buildInstallScript(items, sources);
   const drawerRef = useRef<HTMLDivElement>(null);
 
-  // Trap focus inside the drawer when open (accessibility)
+  // Move initial focus into the drawer when it opens (accessibility)
   useLayoutEffect(() => {
     if (!open) return;
     const el = drawerRef.current;

--- a/assets/src/components/BundleDrawer.tsx
+++ b/assets/src/components/BundleDrawer.tsx
@@ -1,0 +1,112 @@
+import { useLayoutEffect, useRef } from 'preact/hooks';
+import { CopyButton } from './CopyButton.tsx';
+import { buildInstallScript } from '../bundle-state.ts';
+import type { BundleItem } from '../bundle-state.ts';
+
+interface Props {
+  items:    BundleItem[];
+  sources:  Record<string, { isMarketplace: boolean }>;
+  onRemove: (id: string) => void;
+  onClear:  () => void;
+}
+
+const KIND_LABEL: Record<string, string> = {
+  skill:     'skill',
+  agent:     'agent',
+  mcpServer: 'mcp',
+  command:   'cmd',
+  hook:      'hook',
+  plugin:    'plugin',
+};
+
+export function BundleDrawer({ items, sources, onRemove, onClear }: Props) {
+  const open = items.length > 0;
+  const script = buildInstallScript(items, sources);
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  // Trap focus inside the drawer when open (accessibility)
+  useLayoutEffect(() => {
+    if (!open) return;
+    const el = drawerRef.current;
+    if (!el) return;
+    // Move focus to the drawer when it first opens
+    const first = el.querySelector<HTMLElement>('button, [tabindex]');
+    first?.focus();
+  }, [open]);
+
+  // ESC closes (removes all items)
+  useLayoutEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClear();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onClear]);
+
+  return (
+    <div
+      id="bundle-drawer"
+      class={`bundle-drawer${open ? ' bundle-drawer--open' : ''}`}
+      aria-live="polite"
+      aria-label="Custom bundle builder"
+      ref={drawerRef}
+    >
+      {open && (
+        <>
+          <div class="bundle-drawer-header">
+            <span class="bundle-drawer-title">
+              Bundle ({items.length})
+            </span>
+            <button
+              type="button"
+              class="bundle-drawer-clear"
+              aria-label="Clear bundle"
+              onClick={onClear}
+            >
+              Clear
+            </button>
+          </div>
+
+          <ul class="bundle-drawer-list" aria-label="Selected items">
+            {items.map(item => (
+              <li key={item.id} class="bundle-drawer-item">
+                <span class="bundle-drawer-item-kind">{KIND_LABEL[item.kind] ?? item.kind}</span>
+                <span class="bundle-drawer-item-name">{item.name}</span>
+                <button
+                  type="button"
+                  class="bundle-drawer-remove"
+                  aria-label={`Remove ${item.name} from bundle`}
+                  onClick={() => onRemove(item.id)}
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          {script && (
+            <div class="bundle-drawer-script">
+              <pre id="bundle-script">{script}</pre>
+              <CopyButton
+                text={script}
+                label="Copy all"
+                ariaLabel="Copy install script for bundle"
+                className="bundle-drawer-copy"
+                analyticsEvent={{
+                  name:   'install_copy',
+                  params: {
+                    kind:         'bundle',
+                    name:         `custom-${items.length}`,
+                    source:       items[0]?.repo ?? '',
+                    command_type: 'bundle_copy',
+                  },
+                }}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/assets/src/components/Grid.tsx
+++ b/assets/src/components/Grid.tsx
@@ -27,12 +27,19 @@ interface Props {
   activeCategories: Set<string>;
   data:       DataSets;
   sources?:   Record<string, { isMarketplace: boolean }>;
-  onOpenPlugin:  (p: Plugin) => void;
-  onOpenSkill:   (s: Skill) => void;
-  onOpenAgent:   (a: Agent) => void;
-  onOpenMcp:     (m: McpServer) => void;
-  onOpenCommand: (c: Command) => void;
-  onOpenHook:    (h: Hook) => void;
+  bundledIds: Set<string>;
+  onOpenPlugin:    (p: Plugin) => void;
+  onOpenSkill:     (s: Skill) => void;
+  onOpenAgent:     (a: Agent) => void;
+  onOpenMcp:       (m: McpServer) => void;
+  onOpenCommand:   (c: Command) => void;
+  onOpenHook:      (h: Hook) => void;
+  onToggleBundlePlugin:  (p: Plugin) => void;
+  onToggleBundleSkill:   (s: Skill) => void;
+  onToggleBundleAgent:   (a: Agent) => void;
+  onToggleBundleMcp:     (m: McpServer) => void;
+  onToggleBundleCommand: (c: Command) => void;
+  onToggleBundleHook:    (h: Hook) => void;
 }
 
 const GRID_IDS: Record<ViewKey, string> = {
@@ -125,7 +132,7 @@ function viewEmpty(view: ViewKey, icon: string, label: string, allCount: number,
   );
 }
 
-function PluginsGrid({ data, query, sort, activeRepos, activeCategories, onOpenPlugin }: Props) {
+function PluginsGrid({ data, query, sort, activeRepos, activeCategories, onOpenPlugin, bundledIds, onToggleBundlePlugin }: Props) {
   const all = data.plugins;
   const show = multiRepo(all);
   const filtered = all.filter(p => {
@@ -143,13 +150,20 @@ function PluginsGrid({ data, query, sort, activeRepos, activeCategories, onOpenP
         {filtered.length === 0
           ? viewEmpty('plugins', '🔍', 'plugins', all.length, data)
           : sortedBy(filtered, sort).map(p =>
-              <PluginCard key={`${p._repo}/${p.name}`} plugin={p} showSource={show} onOpen={onOpenPlugin} />)}
+              <PluginCard
+                key={`${p._repo}/${p.name}`}
+                plugin={p}
+                showSource={show}
+                onOpen={onOpenPlugin}
+                bundled={bundledIds.has(`plugin/${p.name}`)}
+                onToggleBundle={onToggleBundlePlugin}
+              />)}
       </div>
     </>
   );
 }
 
-function SkillsGrid({ data, query, sort, activeRepos, activeCategories, onOpenSkill }: Props) {
+function SkillsGrid({ data, query, sort, activeRepos, activeCategories, onOpenSkill, bundledIds, onToggleBundleSkill }: Props) {
   const all = data.skills;
   const show = multiRepo(all);
   const filtered = all.filter(s => {
@@ -169,13 +183,21 @@ function SkillsGrid({ data, query, sort, activeRepos, activeCategories, onOpenSk
         {filtered.length === 0
           ? viewEmpty('skills', '🔍', 'skills', all.length, data)
           : sortedBy(filtered, sort).map(s =>
-              <SkillCard key={`${s._repo}/${s.pluginName}/${s.name}`} skill={s} showSource={show} showInstall onOpen={onOpenSkill} />)}
+              <SkillCard
+                key={`${s._repo}/${s.pluginName}/${s.name}`}
+                skill={s}
+                showSource={show}
+                showInstall
+                onOpen={onOpenSkill}
+                bundled={bundledIds.has(`skill/${s.name}`)}
+                onToggleBundle={onToggleBundleSkill}
+              />)}
       </div>
     </>
   );
 }
 
-function AgentsGrid({ data, query, sort, activeRepos, activeCategories, onOpenAgent }: Props) {
+function AgentsGrid({ data, query, sort, activeRepos, activeCategories, onOpenAgent, bundledIds, onToggleBundleAgent }: Props) {
   const all = data.agents;
   const show = multiRepo(all);
   const filtered = all.filter(a => {
@@ -193,13 +215,21 @@ function AgentsGrid({ data, query, sort, activeRepos, activeCategories, onOpenAg
         {filtered.length === 0
           ? viewEmpty('agents', '🤖', 'agents', all.length, data)
           : sortedBy(filtered, sort).map(a =>
-              <AgentCard key={`${a._repo}/${a.pluginName}/${a.name}`} agent={a} showSource={show} showInstall onOpen={onOpenAgent} />)}
+              <AgentCard
+                key={`${a._repo}/${a.pluginName}/${a.name}`}
+                agent={a}
+                showSource={show}
+                showInstall
+                onOpen={onOpenAgent}
+                bundled={bundledIds.has(`agent/${a.name}`)}
+                onToggleBundle={onToggleBundleAgent}
+              />)}
       </div>
     </>
   );
 }
 
-function McpGrid({ data, query, sort, activeRepos, activeCategories, onOpenMcp }: Props) {
+function McpGrid({ data, query, sort, activeRepos, activeCategories, onOpenMcp, bundledIds, onToggleBundleMcp }: Props) {
   const all = data.mcpServers;
   const show = multiRepo(all);
   const filtered = all.filter(m => {
@@ -217,13 +247,21 @@ function McpGrid({ data, query, sort, activeRepos, activeCategories, onOpenMcp }
         {filtered.length === 0
           ? viewEmpty('mcpServers', '🔌', 'MCP servers', all.length, data)
           : sortedBy(filtered, sort).map(m =>
-              <McpCard key={`${m._repo}/${m.pluginName}/${m.name}`} mcp={m} showSource={show} showInstall onOpen={onOpenMcp} />)}
+              <McpCard
+                key={`${m._repo}/${m.pluginName}/${m.name}`}
+                mcp={m}
+                showSource={show}
+                showInstall
+                onOpen={onOpenMcp}
+                bundled={bundledIds.has(`mcpServer/${m.name}`)}
+                onToggleBundle={onToggleBundleMcp}
+              />)}
       </div>
     </>
   );
 }
 
-function CommandsGrid({ data, query, sort, activeRepos, activeCategories, onOpenCommand }: Props) {
+function CommandsGrid({ data, query, sort, activeRepos, activeCategories, onOpenCommand, bundledIds, onToggleBundleCommand }: Props) {
   const all = data.commands;
   const show = multiRepo(all);
   const filtered = all.filter(c => {
@@ -241,13 +279,21 @@ function CommandsGrid({ data, query, sort, activeRepos, activeCategories, onOpen
         {filtered.length === 0
           ? viewEmpty('commands', '⌨️', 'commands', all.length, data)
           : sortedBy(filtered, sort).map(c =>
-              <CommandCard key={`${c._repo}/${c.pluginName}/${c.name}`} command={c} showSource={show} showInstall onOpen={onOpenCommand} />)}
+              <CommandCard
+                key={`${c._repo}/${c.pluginName}/${c.name}`}
+                command={c}
+                showSource={show}
+                showInstall
+                onOpen={onOpenCommand}
+                bundled={bundledIds.has(`command/${c.name}`)}
+                onToggleBundle={onToggleBundleCommand}
+              />)}
       </div>
     </>
   );
 }
 
-function HooksGrid({ data, query, sort, activeRepos, activeCategories, onOpenHook }: Props) {
+function HooksGrid({ data, query, sort, activeRepos, activeCategories, onOpenHook, bundledIds, onToggleBundleHook }: Props) {
   const all = data.hooks;
   const show = multiRepo(all);
   const filtered = all.filter(h => {
@@ -267,7 +313,15 @@ function HooksGrid({ data, query, sort, activeRepos, activeCategories, onOpenHoo
         {filtered.length === 0
           ? viewEmpty('hooks', '🪝', 'hooks', all.length, data)
           : sortedBy(filtered, sort).map(h =>
-              <HookCard key={`${h._repo}/${h.pluginName}/${h.name}`} hook={h} showSource={show} showInstall onOpen={onOpenHook} />)}
+              <HookCard
+                key={`${h._repo}/${h.pluginName}/${h.name}`}
+                hook={h}
+                showSource={show}
+                showInstall
+                onOpen={onOpenHook}
+                bundled={bundledIds.has(`hook/${h.name}`)}
+                onToggleBundle={onToggleBundleHook}
+              />)}
       </div>
     </>
   );

--- a/assets/src/components/Grid.tsx
+++ b/assets/src/components/Grid.tsx
@@ -7,6 +7,7 @@ import { HookCard }    from './cards/HookCard.tsx';
 import { BundleCard }  from './cards/BundleCard.tsx';
 import type { ViewKey } from './Controls.tsx';
 import type { Plugin, Skill, Agent, McpServer, Command, Hook, Bundle } from '../types.ts';
+import { buildBundleItemId } from '../bundle-state.ts';
 
 interface DataSets {
   plugins:    Plugin[];
@@ -155,7 +156,7 @@ function PluginsGrid({ data, query, sort, activeRepos, activeCategories, onOpenP
                 plugin={p}
                 showSource={show}
                 onOpen={onOpenPlugin}
-                bundled={bundledIds.has(`plugin/${p.name}`)}
+                bundled={bundledIds.has(buildBundleItemId('plugin', p.name, p._repo ?? ''))}
                 onToggleBundle={onToggleBundlePlugin}
               />)}
       </div>
@@ -189,7 +190,7 @@ function SkillsGrid({ data, query, sort, activeRepos, activeCategories, onOpenSk
                 showSource={show}
                 showInstall
                 onOpen={onOpenSkill}
-                bundled={bundledIds.has(`skill/${s.name}`)}
+                bundled={bundledIds.has(buildBundleItemId('skill', s.name, s._repo ?? '', s.pluginName))}
                 onToggleBundle={onToggleBundleSkill}
               />)}
       </div>
@@ -221,7 +222,7 @@ function AgentsGrid({ data, query, sort, activeRepos, activeCategories, onOpenAg
                 showSource={show}
                 showInstall
                 onOpen={onOpenAgent}
-                bundled={bundledIds.has(`agent/${a.name}`)}
+                bundled={bundledIds.has(buildBundleItemId('agent', a.name, a._repo ?? '', a.pluginName))}
                 onToggleBundle={onToggleBundleAgent}
               />)}
       </div>
@@ -253,7 +254,7 @@ function McpGrid({ data, query, sort, activeRepos, activeCategories, onOpenMcp, 
                 showSource={show}
                 showInstall
                 onOpen={onOpenMcp}
-                bundled={bundledIds.has(`mcpServer/${m.name}`)}
+                bundled={bundledIds.has(buildBundleItemId('mcpServer', m.name, m._repo ?? '', m.pluginName))}
                 onToggleBundle={onToggleBundleMcp}
               />)}
       </div>
@@ -285,7 +286,7 @@ function CommandsGrid({ data, query, sort, activeRepos, activeCategories, onOpen
                 showSource={show}
                 showInstall
                 onOpen={onOpenCommand}
-                bundled={bundledIds.has(`command/${c.name}`)}
+                bundled={bundledIds.has(buildBundleItemId('command', c.name, c._repo ?? '', c.pluginName))}
                 onToggleBundle={onToggleBundleCommand}
               />)}
       </div>
@@ -319,7 +320,7 @@ function HooksGrid({ data, query, sort, activeRepos, activeCategories, onOpenHoo
                 showSource={show}
                 showInstall
                 onOpen={onOpenHook}
-                bundled={bundledIds.has(`hook/${h.name}`)}
+                bundled={bundledIds.has(buildBundleItemId('hook', h.name, h._repo ?? '', h.pluginName))}
                 onToggleBundle={onToggleBundleHook}
               />)}
       </div>

--- a/assets/src/components/cards/AgentCard.tsx
+++ b/assets/src/components/cards/AgentCard.tsx
@@ -3,18 +3,20 @@ import { CopyButton } from '../CopyButton.tsx';
 import type { Agent } from '../../types.ts';
 
 interface Props {
-  agent:       Agent;
-  showSource:  boolean;
-  showInstall: boolean;
-  onOpen:      (a: Agent) => void;
+  agent:           Agent;
+  showSource:      boolean;
+  showInstall:     boolean;
+  onOpen:          (a: Agent) => void;
+  bundled?:        boolean;
+  onToggleBundle?: (a: Agent) => void;
 }
 
-export function AgentCard({ agent, showSource, showInstall, onOpen }: Props) {
+export function AgentCard({ agent, showSource, showInstall, onOpen, bundled, onToggleBundle }: Props) {
   const catClass = agent.category ? 'badge-' + agent.category : 'badge-uncategorized';
   const catLabel = agent.category ? titleCase(agent.category) : 'Uncategorized';
   const activate = () => onOpen(agent);
   return (
-    <div class="skill-card">
+    <div class={`skill-card${bundled ? ' skill-card--bundled' : ''}`}>
       <div class="card-header">
         <button
           type="button"
@@ -32,20 +34,33 @@ export function AgentCard({ agent, showSource, showInstall, onOpen }: Props) {
         </div>
       </div>
       <p class="card-desc">{agent.description}</p>
-      {showInstall && (
-        <div class="card-install">
-          <code>{agent.installCommand}</code>
-          <CopyButton
-            text={agent.installCommand}
-            ariaLabel={`Copy install command for ${agent.name}`}
-            stopPropagation
-            analyticsEvent={{
-              name:   'install_copy',
-              params: { kind: 'agent', name: agent.name, source: agent._repo ?? '', command_type: 'install' },
-            }}
-          />
-        </div>
-      )}
+      <div class="card-actions">
+        {showInstall && (
+          <div class="card-install">
+            <code>{agent.installCommand}</code>
+            <CopyButton
+              text={agent.installCommand}
+              ariaLabel={`Copy install command for ${agent.name}`}
+              stopPropagation
+              analyticsEvent={{
+                name:   'install_copy',
+                params: { kind: 'agent', name: agent.name, source: agent._repo ?? '', command_type: 'install' },
+              }}
+            />
+          </div>
+        )}
+        {onToggleBundle && (
+          <button
+            type="button"
+            class={`bundle-add-btn${bundled ? ' bundle-add-btn--active' : ''}`}
+            aria-label={bundled ? `Remove ${agent.name} from bundle` : `Add ${agent.name} to bundle`}
+            aria-pressed={bundled}
+            onClick={e => { e.stopPropagation(); onToggleBundle(agent); }}
+          >
+            {bundled ? '✓ Bundled' : '+ Bundle'}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/assets/src/components/cards/CommandCard.tsx
+++ b/assets/src/components/cards/CommandCard.tsx
@@ -3,18 +3,20 @@ import { CopyButton } from '../CopyButton.tsx';
 import type { Command } from '../../types.ts';
 
 interface Props {
-  command:     Command;
-  showSource:  boolean;
-  showInstall: boolean;
-  onOpen:      (c: Command) => void;
+  command:         Command;
+  showSource:      boolean;
+  showInstall:     boolean;
+  onOpen:          (c: Command) => void;
+  bundled?:        boolean;
+  onToggleBundle?: (c: Command) => void;
 }
 
-export function CommandCard({ command: cmd, showSource, showInstall, onOpen }: Props) {
+export function CommandCard({ command: cmd, showSource, showInstall, onOpen, bundled, onToggleBundle }: Props) {
   const catClass = cmd.category ? 'badge-' + cmd.category : 'badge-uncategorized';
   const catLabel = cmd.category ? titleCase(cmd.category) : 'Uncategorized';
   const activate = () => onOpen(cmd);
   return (
-    <div class="skill-card">
+    <div class={`skill-card${bundled ? ' skill-card--bundled' : ''}`}>
       <div class="card-header">
         <button
           type="button"
@@ -31,20 +33,33 @@ export function CommandCard({ command: cmd, showSource, showInstall, onOpen }: P
         </div>
       </div>
       <p class="card-desc">{cmd.description || '—'}</p>
-      {showInstall && (
-        <div class="card-install">
-          <code>{cmd.installCommand}</code>
-          <CopyButton
-            text={cmd.installCommand}
-            ariaLabel={`Copy install command for ${cmd.name}`}
-            stopPropagation
-            analyticsEvent={{
-              name:   'install_copy',
-              params: { kind: 'command', name: cmd.name, source: cmd._repo ?? '', command_type: 'install' },
-            }}
-          />
-        </div>
-      )}
+      <div class="card-actions">
+        {showInstall && (
+          <div class="card-install">
+            <code>{cmd.installCommand}</code>
+            <CopyButton
+              text={cmd.installCommand}
+              ariaLabel={`Copy install command for ${cmd.name}`}
+              stopPropagation
+              analyticsEvent={{
+                name:   'install_copy',
+                params: { kind: 'command', name: cmd.name, source: cmd._repo ?? '', command_type: 'install' },
+              }}
+            />
+          </div>
+        )}
+        {onToggleBundle && (
+          <button
+            type="button"
+            class={`bundle-add-btn${bundled ? ' bundle-add-btn--active' : ''}`}
+            aria-label={bundled ? `Remove ${cmd.name} from bundle` : `Add ${cmd.name} to bundle`}
+            aria-pressed={bundled}
+            onClick={e => { e.stopPropagation(); onToggleBundle(cmd); }}
+          >
+            {bundled ? '✓ Bundled' : '+ Bundle'}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/assets/src/components/cards/HookCard.tsx
+++ b/assets/src/components/cards/HookCard.tsx
@@ -3,19 +3,21 @@ import { CopyButton } from '../CopyButton.tsx';
 import type { Hook } from '../../types.ts';
 
 interface Props {
-  hook:        Hook;
-  showSource:  boolean;
-  showInstall: boolean;
-  onOpen:      (h: Hook) => void;
+  hook:            Hook;
+  showSource:      boolean;
+  showInstall:     boolean;
+  onOpen:          (h: Hook) => void;
+  bundled?:        boolean;
+  onToggleBundle?: (h: Hook) => void;
 }
 
-export function HookCard({ hook, showSource, showInstall, onOpen }: Props) {
+export function HookCard({ hook, showSource, showInstall, onOpen, bundled, onToggleBundle }: Props) {
   const catClass = hook.category ? 'badge-' + hook.category : 'badge-uncategorized';
   const catLabel = hook.category ? titleCase(hook.category) : 'Uncategorized';
   const activate = () => onOpen(hook);
   const events = hook.events.length ? hook.events : ['—'];
   return (
-    <div class="skill-card">
+    <div class={`skill-card${bundled ? ' skill-card--bundled' : ''}`}>
       <div class="card-header">
         <button
           type="button"
@@ -35,20 +37,33 @@ export function HookCard({ hook, showSource, showInstall, onOpen }: Props) {
       <div class="card-chips">
         {events.map(e => <span class="chip chip-hook">{e}</span>)}
       </div>
-      {showInstall && (
-        <div class="card-install">
-          <code>{hook.installCommand}</code>
-          <CopyButton
-            text={hook.installCommand}
-            ariaLabel={`Copy install command for ${hook.name}`}
-            stopPropagation
-            analyticsEvent={{
-              name:   'install_copy',
-              params: { kind: 'hook', name: hook.name, source: hook._repo ?? '', command_type: 'install' },
-            }}
-          />
-        </div>
-      )}
+      <div class="card-actions">
+        {showInstall && (
+          <div class="card-install">
+            <code>{hook.installCommand}</code>
+            <CopyButton
+              text={hook.installCommand}
+              ariaLabel={`Copy install command for ${hook.name}`}
+              stopPropagation
+              analyticsEvent={{
+                name:   'install_copy',
+                params: { kind: 'hook', name: hook.name, source: hook._repo ?? '', command_type: 'install' },
+              }}
+            />
+          </div>
+        )}
+        {onToggleBundle && (
+          <button
+            type="button"
+            class={`bundle-add-btn${bundled ? ' bundle-add-btn--active' : ''}`}
+            aria-label={bundled ? `Remove ${hook.name} from bundle` : `Add ${hook.name} to bundle`}
+            aria-pressed={bundled}
+            onClick={e => { e.stopPropagation(); onToggleBundle(hook); }}
+          >
+            {bundled ? '✓ Bundled' : '+ Bundle'}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/assets/src/components/cards/McpCard.tsx
+++ b/assets/src/components/cards/McpCard.tsx
@@ -3,18 +3,20 @@ import { CopyButton } from '../CopyButton.tsx';
 import type { McpServer } from '../../types.ts';
 
 interface Props {
-  mcp:         McpServer;
-  showSource:  boolean;
-  showInstall: boolean;
-  onOpen:      (m: McpServer) => void;
+  mcp:             McpServer;
+  showSource:      boolean;
+  showInstall:     boolean;
+  onOpen:          (m: McpServer) => void;
+  bundled?:        boolean;
+  onToggleBundle?: (m: McpServer) => void;
 }
 
-export function McpCard({ mcp, showSource, showInstall, onOpen }: Props) {
+export function McpCard({ mcp, showSource, showInstall, onOpen, bundled, onToggleBundle }: Props) {
   const catClass = mcp.category ? 'badge-' + mcp.category : 'badge-uncategorized';
   const catLabel = mcp.category ? titleCase(mcp.category) : 'Uncategorized';
   const activate = () => onOpen(mcp);
   return (
-    <div class="skill-card">
+    <div class={`skill-card${bundled ? ' skill-card--bundled' : ''}`}>
       <div class="card-header">
         <button
           type="button"
@@ -31,20 +33,33 @@ export function McpCard({ mcp, showSource, showInstall, onOpen }: Props) {
         </div>
       </div>
       <p class="card-desc">{mcp.description}</p>
-      {showInstall && (
-        <div class="card-install">
-          <code>{mcp.installCommand}</code>
-          <CopyButton
-            text={mcp.installCommand}
-            ariaLabel={`Copy install command for ${mcp.name}`}
-            stopPropagation
-            analyticsEvent={{
-              name:   'install_copy',
-              params: { kind: 'mcpServer', name: mcp.name, source: mcp._repo ?? '', command_type: 'install' },
-            }}
-          />
-        </div>
-      )}
+      <div class="card-actions">
+        {showInstall && (
+          <div class="card-install">
+            <code>{mcp.installCommand}</code>
+            <CopyButton
+              text={mcp.installCommand}
+              ariaLabel={`Copy install command for ${mcp.name}`}
+              stopPropagation
+              analyticsEvent={{
+                name:   'install_copy',
+                params: { kind: 'mcpServer', name: mcp.name, source: mcp._repo ?? '', command_type: 'install' },
+              }}
+            />
+          </div>
+        )}
+        {onToggleBundle && (
+          <button
+            type="button"
+            class={`bundle-add-btn${bundled ? ' bundle-add-btn--active' : ''}`}
+            aria-label={bundled ? `Remove ${mcp.name} from bundle` : `Add ${mcp.name} to bundle`}
+            aria-pressed={bundled}
+            onClick={e => { e.stopPropagation(); onToggleBundle(mcp); }}
+          >
+            {bundled ? '✓ Bundled' : '+ Bundle'}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/assets/src/components/cards/PluginCard.tsx
+++ b/assets/src/components/cards/PluginCard.tsx
@@ -8,12 +8,14 @@ const CHIP_LIMIT = 5;
 interface Chip { cls: string; text: string; }
 
 interface Props {
-  plugin:     Plugin;
-  showSource: boolean;
-  onOpen:     (plugin: Plugin) => void;
+  plugin:          Plugin;
+  showSource:      boolean;
+  onOpen:          (plugin: Plugin) => void;
+  bundled?:        boolean;
+  onToggleBundle?: (plugin: Plugin) => void;
 }
 
-export function PluginCard({ plugin, showSource, onOpen }: Props) {
+export function PluginCard({ plugin, showSource, onOpen, bundled, onToggleBundle }: Props) {
   const catClass = plugin.category ? 'badge-' + plugin.category : 'badge-uncategorized';
   const catLabel = plugin.category ? titleCase(plugin.category) : 'Uncategorized';
   const description = plugin.description ?? '';
@@ -29,7 +31,7 @@ export function PluginCard({ plugin, showSource, onOpen }: Props) {
   const activate = () => onOpen(plugin);
 
   return (
-    <div class="skill-card">
+    <div class={`skill-card${bundled ? ' skill-card--bundled' : ''}`}>
       <div class="card-header">
         <button
           type="button"
@@ -55,17 +57,30 @@ export function PluginCard({ plugin, showSource, onOpen }: Props) {
           renderItem={({ cls, text }) => <span class={`chip ${cls}`}>{text}</span>}
         />
       )}
-      <div class="card-install">
-        <code>{plugin.installCommand}</code>
-        <CopyButton
-          text={plugin.installCommand}
-          ariaLabel={`Copy install command for ${plugin.name}`}
-          stopPropagation
-          analyticsEvent={{
-            name:   'install_copy',
-            params: { kind: 'plugin', name: plugin.name, source: plugin._repo ?? '', command_type: 'install' },
-          }}
-        />
+      <div class="card-actions">
+        <div class="card-install">
+          <code>{plugin.installCommand}</code>
+          <CopyButton
+            text={plugin.installCommand}
+            ariaLabel={`Copy install command for ${plugin.name}`}
+            stopPropagation
+            analyticsEvent={{
+              name:   'install_copy',
+              params: { kind: 'plugin', name: plugin.name, source: plugin._repo ?? '', command_type: 'install' },
+            }}
+          />
+        </div>
+        {onToggleBundle && (
+          <button
+            type="button"
+            class={`bundle-add-btn${bundled ? ' bundle-add-btn--active' : ''}`}
+            aria-label={bundled ? `Remove ${plugin.name} from bundle` : `Add ${plugin.name} to bundle`}
+            aria-pressed={bundled}
+            onClick={e => { e.stopPropagation(); onToggleBundle(plugin); }}
+          >
+            {bundled ? '✓ Bundled' : '+ Bundle'}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/assets/src/components/cards/SkillCard.tsx
+++ b/assets/src/components/cards/SkillCard.tsx
@@ -3,19 +3,21 @@ import { CopyButton } from '../CopyButton.tsx';
 import type { Skill } from '../../types.ts';
 
 interface Props {
-  skill:       Skill;
-  showSource:  boolean;
-  showInstall: boolean;
-  onOpen:      (skill: Skill) => void;
+  skill:        Skill;
+  showSource:   boolean;
+  showInstall:  boolean;
+  onOpen:       (skill: Skill) => void;
+  bundled?:     boolean;
+  onToggleBundle?: (skill: Skill) => void;
 }
 
-export function SkillCard({ skill, showSource, showInstall, onOpen }: Props) {
+export function SkillCard({ skill, showSource, showInstall, onOpen, bundled, onToggleBundle }: Props) {
   const catClass = skill.category ? 'badge-' + skill.category : 'badge-uncategorized';
   const catLabel = skill.category ? titleCase(skill.category) : 'Uncategorized';
   const activate = () => onOpen(skill);
 
   return (
-    <div class="skill-card">
+    <div class={`skill-card${bundled ? ' skill-card--bundled' : ''}`}>
       <div class="card-header">
         <button
           type="button"
@@ -33,20 +35,33 @@ export function SkillCard({ skill, showSource, showInstall, onOpen }: Props) {
         </div>
       </div>
       <p class="card-desc">{skill.description}</p>
-      {showInstall && (
-        <div class="card-install">
-          <code>{skill.installCommand}</code>
-          <CopyButton
-            text={skill.installCommand}
-            ariaLabel={`Copy install command for ${skill.name}`}
-            stopPropagation
-            analyticsEvent={{
-              name:   'install_copy',
-              params: { kind: 'skill', name: skill.name, source: skill._repo ?? '', command_type: 'install' },
-            }}
-          />
-        </div>
-      )}
+      <div class="card-actions">
+        {showInstall && (
+          <div class="card-install">
+            <code>{skill.installCommand}</code>
+            <CopyButton
+              text={skill.installCommand}
+              ariaLabel={`Copy install command for ${skill.name}`}
+              stopPropagation
+              analyticsEvent={{
+                name:   'install_copy',
+                params: { kind: 'skill', name: skill.name, source: skill._repo ?? '', command_type: 'install' },
+              }}
+            />
+          </div>
+        )}
+        {onToggleBundle && (
+          <button
+            type="button"
+            class={`bundle-add-btn${bundled ? ' bundle-add-btn--active' : ''}`}
+            aria-label={bundled ? `Remove ${skill.name} from bundle` : `Add ${skill.name} to bundle`}
+            aria-pressed={bundled}
+            onClick={e => { e.stopPropagation(); onToggleBundle(skill); }}
+          >
+            {bundled ? '✓ Bundled' : '+ Bundle'}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/assets/src/gtag-types.ts
+++ b/assets/src/gtag-types.ts
@@ -5,8 +5,8 @@ declare global {
   }
 }
 
-type EntityKind  = 'marketplace' | 'plugin' | 'skill' | 'agent' | 'mcpServer' | 'command' | 'hook';
-type CommandType = 'marketplace_add' | 'install';
+type EntityKind  = 'marketplace' | 'plugin' | 'skill' | 'agent' | 'mcpServer' | 'command' | 'hook' | 'bundle';
+type CommandType = 'marketplace_add' | 'install' | 'bundle_copy';
 
 export interface InstallCopyParams {
   kind:         EntityKind;

--- a/assets/src/url-state.ts
+++ b/assets/src/url-state.ts
@@ -4,7 +4,7 @@ export interface UrlState {
   sort:   'az' | 'za';
   repos:  string[];
   cats:   string[];
-  bundle: string[];   // encoded as "name|installCommand" pairs
+  bundle: string[];   // encoded bundle item tokens (see bundle-state.ts)
 }
 
 export function readUrlState(): UrlState {

--- a/assets/src/url-state.ts
+++ b/assets/src/url-state.ts
@@ -1,19 +1,21 @@
 export interface UrlState {
-  view:  string;
-  query: string;
-  sort:  'az' | 'za';
-  repos: string[];
-  cats:  string[];
+  view:   string;
+  query:  string;
+  sort:   'az' | 'za';
+  repos:  string[];
+  cats:   string[];
+  bundle: string[];   // encoded as "name|installCommand" pairs
 }
 
 export function readUrlState(): UrlState {
   const params = new URLSearchParams(location.hash.slice(1));
   return {
-    view:  params.get('view') ?? 'plugins',
-    query: params.get('q')    ?? '',
-    sort:  (params.get('sort') ?? 'az') as 'az' | 'za',
-    repos: params.getAll('repo'),
-    cats:  params.getAll('cat'),
+    view:   params.get('view') ?? 'plugins',
+    query:  params.get('q')    ?? '',
+    sort:   (params.get('sort') ?? 'az') as 'az' | 'za',
+    repos:  params.getAll('repo'),
+    cats:   params.getAll('cat'),
+    bundle: params.getAll('b'),
   };
 }
 
@@ -22,8 +24,9 @@ export function writeUrlState(s: UrlState): void {
   if (s.view !== 'plugins') params.set('view', s.view);
   if (s.query)              params.set('q', s.query);
   if (s.sort !== 'az')      params.set('sort', s.sort);
-  for (const repo of s.repos) params.append('repo', repo);
-  for (const cat  of s.cats)  params.append('cat',  cat);
+  for (const repo   of s.repos)  params.append('repo', repo);
+  for (const cat    of s.cats)   params.append('cat',  cat);
+  for (const item   of s.bundle) params.append('b',    item);
   const qs = params.toString();
   history.replaceState(null, '', qs ? `#${qs}` : location.pathname + location.search);
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -1233,6 +1233,196 @@ body.catalog-page footer {
 .panel-section[hidden] { display: none; }
 
 
+/* ── Bundle add button (on cards) ── */
+.card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
+}
+.card-actions .card-install {
+  flex: 1;
+  min-width: 0;
+}
+
+.bundle-add-btn {
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  padding: 3px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.bundle-add-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+.bundle-add-btn--active {
+  color: var(--green);
+  border-color: var(--green);
+  background: var(--green-dim);
+}
+.bundle-add-btn--active:hover {
+  color: #f85149;
+  border-color: #f85149;
+  background: rgba(248,81,73,0.1);
+}
+
+/* Highlight cards that are in the current bundle */
+.skill-card--bundled {
+  border-color: var(--green);
+}
+.skill-card--bundled:hover {
+  border-color: var(--green);
+}
+
+/* ── Bundle Drawer ── */
+.bundle-drawer {
+  position: fixed;
+  bottom: 48px;   /* sit above footer */
+  right: 24px;
+  width: min(380px, calc(100vw - 32px));
+  max-height: calc(100vh - 120px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.55);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  /* Hidden by default — shown when items are present */
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.bundle-drawer--open {
+  pointer-events: all;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.bundle-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px 10px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.bundle-drawer-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.bundle-drawer-clear {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.bundle-drawer-clear:hover { color: #f85149; border-color: #f85149; }
+
+.bundle-drawer-list {
+  list-style: none;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  padding: 8px 0;
+  margin: 0;
+  max-height: 220px;
+}
+
+.bundle-drawer-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 16px;
+  font-size: 0.8rem;
+}
+.bundle-drawer-item:hover { background: var(--surface-hover); }
+
+.bundle-drawer-item-kind {
+  font-size: 0.65rem;
+  background: var(--accent-dim);
+  color: var(--accent);
+  border-radius: 4px;
+  padding: 1px 5px;
+  flex-shrink: 0;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.bundle-drawer-item-name {
+  flex: 1;
+  color: var(--text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bundle-drawer-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+.bundle-drawer-remove:hover { color: #f85149; }
+
+.bundle-drawer-script {
+  position: relative;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  padding: 12px 16px;
+  background: var(--bg);
+}
+.bundle-drawer-script pre {
+  font-size: 0.72rem;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding-right: 54px;
+  margin: 0;
+  line-height: 1.6;
+  max-height: 120px;
+  overflow-y: auto;
+}
+.bundle-drawer-copy {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+.bundle-drawer-copy:hover { color: var(--accent); border-color: var(--accent); }
+.bundle-drawer-copy.copied { color: var(--green); border-color: var(--green); }
+
 /* ── Responsive ── */
 @media (max-width: 640px) {
   header, .quickstart, .controls, .marketplace-bar, main, footer { padding-left: 16px; padding-right: 16px; }
@@ -1249,11 +1439,18 @@ body.catalog-page footer {
 
   /* 44×44px minimum touch target */
   .filter-btn, .sort-btn, .view-btn, .copy-btn, .expand-btn,
-  .bundle-copy-btn, .panel-close-btn, .panel-copy-btn, #panel-install-copy {
+  .bundle-copy-btn, .panel-close-btn, .panel-copy-btn, #panel-install-copy,
+  .bundle-add-btn, .bundle-drawer-clear, .bundle-drawer-remove {
     min-height: 44px;
     min-width: 44px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+  }
+
+  .bundle-drawer {
+    right: 8px;
+    bottom: 56px;
+    width: calc(100vw - 16px);
   }
 }

--- a/tests/bundle-builder.test.ts
+++ b/tests/bundle-builder.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Custom Bundle Builder regression tests.
+ *
+ * Covers:
+ *  - add/remove skill cards via + Bundle button
+ *  - bundle drawer opens on first selection, hides when empty
+ *  - install-script generation (deduplication, correct commands)
+ *  - URL hash persistence (b= params)
+ *  - URL round-trip (boot from hash)
+ *  - Copy-all button copies the install script
+ *  - Clear button empties the bundle
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp, click, flush } from './harness.ts';
+
+// Switch to the skills view, returning card name buttons
+async function openSkillsView() {
+  await bootApp();
+  click('#view-skills');
+  await flush();
+}
+
+function bundleButton(skillName: string): HTMLButtonElement | null {
+  const cards = document.querySelectorAll('#skills-grid .skill-card');
+  for (const card of Array.from(cards)) {
+    const nameEl = card.querySelector('.card-name-text');
+    if (nameEl?.textContent === skillName) {
+      return card.querySelector<HTMLButtonElement>('.bundle-add-btn');
+    }
+  }
+  return null;
+}
+
+function drawerVisible(): boolean {
+  return document.querySelector('#bundle-drawer')?.classList.contains('bundle-drawer--open') ?? false;
+}
+
+function drawerItems(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('#bundle-drawer .bundle-drawer-item-name')
+  ).map(el => el.textContent ?? '');
+}
+
+function scriptText(): string {
+  return document.querySelector<HTMLElement>('#bundle-script')?.textContent ?? '';
+}
+
+describe('Custom bundle builder — add/remove', () => {
+  it('bundle drawer is hidden when nothing is selected', async () => {
+    await openSkillsView();
+    expect(drawerVisible()).toBe(false);
+  });
+
+  it('clicking + Bundle on a skill opens the drawer', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    await flush();
+    expect(drawerVisible()).toBe(true);
+  });
+
+  it('selected skill appears in the drawer list', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    await flush();
+    expect(drawerItems()).toContain('changelog');
+  });
+
+  it('button label changes to "✓ Bundled" after selection', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    await flush();
+    const btn = bundleButton('changelog');
+    expect(btn?.textContent).toContain('Bundled');
+  });
+
+  it('clicking the button again removes the item and reverts label', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    await flush();
+    bundleButton('changelog')?.click();
+    await flush();
+    expect(drawerItems()).not.toContain('changelog');
+    const btn = bundleButton('changelog');
+    expect(btn?.textContent).toContain('+ Bundle');
+  });
+
+  it('drawer hides when all items are removed', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    await flush();
+    bundleButton('changelog')?.click();
+    await flush();
+    expect(drawerVisible()).toBe(false);
+  });
+
+  it('can add multiple skills and all appear in the drawer', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    bundleButton('find-dead-code')?.click();
+    await flush();
+    const items = drawerItems();
+    expect(items).toContain('changelog');
+    expect(items).toContain('find-dead-code');
+  });
+
+  it('remove button inside drawer removes that item', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    bundleButton('find-dead-code')?.click();
+    await flush();
+    // Find the remove button for 'changelog'
+    const drawerItemEls = document.querySelectorAll<HTMLElement>('#bundle-drawer .bundle-drawer-item');
+    for (const el of Array.from(drawerItemEls)) {
+      if (el.querySelector('.bundle-drawer-item-name')?.textContent === 'changelog') {
+        el.querySelector<HTMLButtonElement>('.bundle-drawer-remove')?.click();
+        break;
+      }
+    }
+    await flush();
+    expect(drawerItems()).not.toContain('changelog');
+    expect(drawerItems()).toContain('find-dead-code');
+  });
+
+  it('clear button empties the drawer', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    bundleButton('find-dead-code')?.click();
+    await flush();
+    click('#bundle-drawer .bundle-drawer-clear');
+    await flush();
+    expect(drawerVisible()).toBe(false);
+    expect(drawerItems()).toHaveLength(0);
+  });
+});
+
+describe('Custom bundle builder — install script', () => {
+  it('generates an install command for the selected skill', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    await flush();
+    const script = scriptText();
+    expect(script).toContain('/plugin install');
+    expect(script).toContain('easier-life-skills');
+  });
+
+  it('deduplicates skills that share the same install command', async () => {
+    await openSkillsView();
+    // Both changelog and document-project belong to the docs plugin
+    bundleButton('changelog')?.click();
+    bundleButton('document-project')?.click();
+    await flush();
+    const script = scriptText();
+    // The install command should appear only once, not twice
+    const matches = script.match(/\/plugin install docs@easier-life-skills/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('copy-all button copies the install script', async () => {
+    const { clipboardWrites } = await bootApp();
+    click('#view-skills');
+    await flush();
+    bundleButton('changelog')?.click();
+    await flush();
+    click('#bundle-drawer .bundle-drawer-copy');
+    await flush();
+    expect(clipboardWrites.length).toBeGreaterThan(0);
+    expect(clipboardWrites[clipboardWrites.length - 1]).toContain('/plugin install');
+  });
+});
+
+describe('Custom bundle builder — URL persistence', () => {
+  it('selected items are encoded in the URL hash', async () => {
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    await flush();
+    expect(location.hash).toContain('b=');
+  });
+
+  it('round-trips: bundle survives a page reload (boot from hash)', async () => {
+    // First boot: select a skill to get the hash
+    await openSkillsView();
+    bundleButton('changelog')?.click();
+    await flush();
+    const hash = location.hash;
+    expect(hash).toContain('b=');
+
+    // Second boot: restore state from hash
+    await bootApp({ hash });
+    click('#view-skills');
+    await flush();
+    expect(drawerVisible()).toBe(true);
+    expect(drawerItems()).toContain('changelog');
+  });
+
+  it('corrupt b= token in hash is silently ignored', async () => {
+    await bootApp({ hash: '#b=corrupt%7Ctoken' });
+    await flush();
+    // Should not crash, drawer should be empty
+    expect(drawerVisible()).toBe(false);
+  });
+});

--- a/tests/skill-name-collision.test.ts
+++ b/tests/skill-name-collision.test.ts
@@ -188,4 +188,19 @@ describe('same-name skills across plugins', () => {
     bundleSection = document.getElementById('panel-bundles-section');
     expect(bundleSection?.style.display).toBe('none');
   });
+
+  it('bundling one same-name skill does not mark the others as bundled', async () => {
+    await bootApp({ fixture: FIXTURE });
+    click('#view-skills');
+    await flush();
+
+    const cards = Array.from(document.querySelectorAll<HTMLElement>('#skills-grid .skill-card'));
+    const docsCard = cards.find(card => card.querySelector('.card-desc')?.textContent === 'CHANGELOG.md (docs flavour)');
+    docsCard?.querySelector<HTMLButtonElement>('.bundle-add-btn')?.click();
+    await flush();
+
+    const bundledButtons = Array.from(document.querySelectorAll<HTMLElement>('#skills-grid .bundle-add-btn'))
+      .filter(btn => (btn.textContent ?? '').includes('Bundled'));
+    expect(bundledButtons).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds an **\"+ Bundle\" button** on every card (skills, agents, MCP servers, commands, hooks, plugins) that lets users curate a custom set of items.
- New **`BundleDrawer`** component pinned bottom-right: opens on first selection, lists picked items with a remove (×) button each, generates an install script, provides a \"Copy all\" button, and closes when the bundle is empty (ESC also clears it).
- **URL persistence**: selection is round-tripped via `b=` params in the hash so bundles are shareable links that survive page reloads.
- Install script **deduplicates** install commands shared by multiple skills from the same plugin.
- 15 regression tests cover add/remove, deduplication, URL round-trip, copy-all, and corrupt-token resilience.

Closes #10

---
*Opened by multi-repo-tasks via Claude Code.*