### PR TITLE
feat(dependency-audit): add dependency-audit skill plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,6 +41,13 @@
       "homepage": "https://github.com/dan323/easier-life-skills/tree/master/plugins/cv-linkedin"
     },
     {
+      "name": "dependency-audit",
+      "source": "./plugins/dependency-audit",
+      "description": "Scan all dependencies for outdated versions and known vulnerabilities. Uses npm audit, pip-audit, cargo audit, and bundler-audit with grep-based fallbacks. Read-only report.",
+      "category": "security",
+      "homepage": "https://github.com/dan323/easier-life-skills/tree/master/plugins/dependency-audit"
+    },
+    {
       "name": "docs",
       "source": "./plugins/docs",
       "description": "Documentation skills: generate or update CHANGELOG.md from git history, and create a root README.md with a linked /docs structure",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "installer": {
       "name": "@dan323/easier-life-skills",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "bin": {
         "easier-life-skills": "dist/bin/install.js"
@@ -66,7 +66,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1549,7 +1548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1890,7 +1888,6 @@
       "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -2363,7 +2360,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2542,7 +2538,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2615,7 +2610,6 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/plugins/dependency-audit/.claude-plugin/plugin.json
+++ b/plugins/dependency-audit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "dependency-audit",
+  "version": "1.0.0",
+  "description": "Scan all dependencies for outdated versions and known vulnerabilities. Uses npm audit, pip-audit, cargo audit, and bundler-audit with grep-based fallbacks. Read-only report.",
+  "author": { "name": "dan323" },
+  "category": "security",
+  "skills": ["./skills/dependency-audit"]
+}

--- a/plugins/dependency-audit/skills/dependency-audit/SKILL.md
+++ b/plugins/dependency-audit/skills/dependency-audit/SKILL.md
@@ -70,7 +70,7 @@ Skip `package.json` files found inside `node_modules/`.
 Check which audit tools are installed:
 
 ```bash
-command -v npm yarn pnpm cargo pip pip3 pip-audit poetry pipenv bundle gem go mvn gradle composer 2>/dev/null
+command -v npm yarn pnpm cargo cargo-audit cargo-outdated pip pip3 pip-audit safety poetry pipenv bundle bundle-audit bundler-audit gem go govulncheck mvn gradle composer local-php-security-checker 2>/dev/null
 ```
 
 ---

--- a/plugins/dependency-audit/skills/dependency-audit/SKILL.md
+++ b/plugins/dependency-audit/skills/dependency-audit/SKILL.md
@@ -123,17 +123,23 @@ Parse `vulnerabilities.list[]` from the JSON output. Record package, version, RU
 
 **Tool available** (`pip-audit` preferred, then `safety`):
 
-```bash
-# pip-audit
-pip-audit --format json 2>/dev/null
+Run the audit against each discovered manifest — do **not** run against the interpreter environment, as that reflects globally installed packages rather than project dependencies:
 
-# safety (legacy)
-safety check --json 2>/dev/null
+```bash
+# pip-audit against each requirements*.txt found in Phase 1
+pip-audit -r <requirements.txt> --format json 2>/dev/null
+
+# pip-audit for Pipfile.lock / pyproject.toml / poetry.lock:
+# run in the directory containing the manifest (pip-audit auto-detects these formats)
+# e.g. cd <manifest-dir> && pip-audit --format json 2>/dev/null
+
+# safety (legacy) — run against each requirements file
+safety check -r <requirements.txt> --json 2>/dev/null
 ```
 
 Parse JSON output. Record package, installed version, vulnerability ID (CVE or PYSEC), and description.
 
-**Fallback** — use `pip list --format json` (or parse `requirements*.txt` / `Pipfile.lock` / `poetry.lock`) to enumerate installed packages. Note that no vulnerability check could be performed and list all packages for manual review.
+**Fallback** — parse `requirements*.txt`, `Pipfile.lock`, or `poetry.lock` directly to enumerate declared packages and their pinned versions. Note that no vulnerability check could be performed and list all packages for manual review. Do **not** use `pip list` — it reflects the interpreter environment rather than the project manifests.
 
 ### Ruby (bundler)
 
@@ -149,24 +155,49 @@ bundle-audit check --format json 2>/dev/null || bundle audit check 2>/dev/null
 
 **Tool available** (`govulncheck`):
 
+Run with module writes disabled to prevent `go.sum`/`go.mod` from being modified:
+
 ```bash
-govulncheck ./... 2>/dev/null
+GOFLAGS=-mod=readonly govulncheck ./... 2>/dev/null
 ```
 
-**Fallback** — parse `go.sum` or `go.mod` for module paths and versions. Attempt `go list -m -u all 2>/dev/null` to detect available updates.
+If the repo is not tidy (missing sums), `govulncheck` may fail with `-mod=readonly`. In that case, fall back to parsing `go.mod` and `go.sum` directly — do **not** run `go mod tidy` or any command that mutates project files.
+
+**Fallback** — parse `go.sum` or `go.mod` for module paths and versions and list them for manual review. Attempt to detect available updates read-only:
+
+```bash
+GOFLAGS=-mod=readonly go list -m -u all 2>/dev/null
+```
 
 ### Java (Maven / Gradle)
 
 **Tool available**:
 
+The OWASP dependency-check plugin writes its report and NVD data cache to `target/` or `build/` by default, violating this skill's read-only guarantee. Redirect all output to a temporary directory and clean it up afterwards:
+
 ```bash
+_DC_TMP=$(mktemp -d)
+
 # Maven OWASP dependency-check plugin (if wrapper present)
-./mvnw dependency-check:check -DfailBuildOnCVSS=0 2>/dev/null \
-  || mvn dependency-check:check -DfailBuildOnCVSS=0 2>/dev/null
+./mvnw dependency-check:check -DfailBuildOnCVSS=0 \
+  -Dodc.reports.dir="$_DC_TMP/reports" \
+  -DdataDirectory="$_DC_TMP/nvdcache" \
+  -Dformat=JSON 2>/dev/null \
+  || mvn dependency-check:check -DfailBuildOnCVSS=0 \
+  -Dodc.reports.dir="$_DC_TMP/reports" \
+  -DdataDirectory="$_DC_TMP/nvdcache" \
+  -Dformat=JSON 2>/dev/null
 
 # Gradle (if wrapper present)
-./gradlew dependencyCheckAnalyze 2>/dev/null \
-  || gradle dependencyCheckAnalyze 2>/dev/null
+./gradlew dependencyCheckAnalyze \
+  -PdependencyCheck.outputDirectory="$_DC_TMP/reports" \
+  -PdependencyCheck.dataDirectory="$_DC_TMP/nvdcache" 2>/dev/null \
+  || gradle dependencyCheckAnalyze \
+  -PdependencyCheck.outputDirectory="$_DC_TMP/reports" \
+  -PdependencyCheck.dataDirectory="$_DC_TMP/nvdcache" 2>/dev/null
+
+# Parse JSON report from $_DC_TMP/reports/ then remove the temp dir
+rm -rf "$_DC_TMP"
 ```
 
 **Fallback** — parse `pom.xml` or `build.gradle` for declared dependency coordinates and list them for manual review.
@@ -208,9 +239,16 @@ If `cargo-outdated` is not installed, skip — do not attempt to install it.
 
 ### Python
 
-```bash
-pip list --outdated --format json 2>/dev/null
-```
+Python outdated detection without an installed environment is unreliable: `pip list --outdated` reflects the interpreter environment, not the project manifests, and will produce false results in arbitrary repos where dependencies are not installed.
+
+Instead, use manifest-based detection:
+
+1. Parse pinned versions from each discovered `requirements*.txt`, `Pipfile.lock`, or `pyproject.toml` (poetry).
+2. If `pip-audit` supports version comparison for the discovered manifest, check its output for packages where `latest_version` differs from the pinned version:
+   ```bash
+   pip-audit -r <requirements.txt> --format json 2>/dev/null
+   ```
+3. If no tool can determine latest versions without an installed environment, list the pinned versions from the manifests in the report and explicitly note that outdated checks for Python could not be performed without an active environment.
 
 ### Ruby
 

--- a/plugins/dependency-audit/skills/dependency-audit/SKILL.md
+++ b/plugins/dependency-audit/skills/dependency-audit/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: dependency-audit
+description: >
+  Scan all dependencies for outdated versions and known security vulnerabilities.
+  Uses npm audit / pip-audit / cargo audit / bundler-audit with grep-based fallbacks
+  when dedicated tools are unavailable. Produces a prioritised, read-only report.
+  Use when the user asks to "audit dependencies", "check for vulnerabilities",
+  "find outdated packages", "run a dependency audit", "check npm audit",
+  "scan for CVEs in dependencies", or anything about dependency security or freshness.
+tools: Bash, PowerShell, Read, Glob, Grep, TaskCreate, TaskUpdate
+model: sonnet
+---
+
+# Dependency Audit
+
+Scan every dependency manifest in the current project for:
+1. **Known security vulnerabilities** — CVE / advisory database hits reported by the ecosystem's native audit tool.
+2. **Outdated versions** — packages where a newer stable release exists.
+
+Produce a single, prioritised, read-only report. Never modify `package.json`, `Cargo.toml`, lock files, or any other project file.
+
+**This skill is read-only.** It reports findings. It does not install, upgrade, or patch anything.
+
+---
+
+## Task Tracking
+
+Before doing any work, call `TaskCreate` for each phase below. Call `TaskUpdate` (status `in_progress`) when you begin a phase and `TaskUpdate` (status `completed`) when you finish it.
+
+- Detect ecosystems and manifests
+- Run vulnerability audits
+- Check for outdated packages
+- Consolidate and rank findings
+- Write report
+
+---
+
+## Phase 1 — Detect Ecosystems and Manifests
+
+Search the project root (and up to 3 levels deep) for known dependency manifests:
+
+```bash
+find . -maxdepth 3 \
+  -not -path "*/.git/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.venv/*" \
+  -not -path "*/vendor/*" \
+  \( \
+    -name "package.json" \
+    -o -name "Cargo.toml" \
+    -o -name "requirements*.txt" \
+    -o -name "pyproject.toml" \
+    -o -name "Pipfile" \
+    -o -name "Gemfile" \
+    -o -name "go.mod" \
+    -o -name "pom.xml" \
+    -o -name "build.gradle" \
+    -o -name "build.gradle.kts" \
+    -o -name "composer.json" \
+  \) | sort
+```
+
+For each manifest found, identify:
+- **Ecosystem**: Node.js / Rust / Python / Ruby / Go / Java (Maven or Gradle) / PHP
+- **Package manager**: npm / yarn / pnpm / cargo / pip / poetry / pipenv / bundler / go modules / maven / gradle / composer
+- **Lock file present?**: `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`, `poetry.lock`, `Pipfile.lock`, `Gemfile.lock`, `go.sum`
+
+Skip `package.json` files found inside `node_modules/`.
+
+Check which audit tools are installed:
+
+```bash
+command -v npm yarn pnpm cargo pip pip3 pip-audit poetry pipenv bundle gem go mvn gradle composer 2>/dev/null
+```
+
+---
+
+## Phase 2 — Run Vulnerability Audits
+
+For each detected ecosystem, run its native audit tool if available. Fall back to advisory-database grep when the tool is absent. Run ecosystems in parallel where possible.
+
+### Node.js (npm / yarn / pnpm)
+
+**Tool available** — run inside each directory containing a `package.json`:
+
+```bash
+# npm
+npm audit --json 2>/dev/null
+
+# yarn v1
+yarn audit --json 2>/dev/null
+
+# pnpm
+pnpm audit --json 2>/dev/null
+```
+
+Parse the JSON output. For each vulnerability, record:
+- Package name
+- Installed version
+- Severity (`critical` / `high` / `moderate` / `low` / `info`)
+- CVE or advisory ID (if present)
+- One-line description
+
+**Fallback (no npm/yarn/pnpm)** — read `package-lock.json` or `yarn.lock`, extract package names and versions, then check against the [npm advisory API](https://registry.npmjs.org/-/npm/v1/security/advisories/bulk) using `curl` if available. If `curl` is unavailable, note that no vulnerability check could be performed and list all direct dependencies with their pinned versions for manual review.
+
+### Rust (cargo)
+
+**Tool available**:
+
+```bash
+cargo audit --json 2>/dev/null
+```
+
+Parse `vulnerabilities.list[]` from the JSON output. Record package, version, RUSTSEC ID, and title.
+
+**Fallback** — parse `Cargo.lock` for package names and versions. Cross-reference with the RustSec advisory database RSS feed via `curl https://rustsec.org/feed.xml` if network access is available; otherwise list all crate versions for manual review.
+
+### Python (pip / poetry / pipenv)
+
+**Tool available** (`pip-audit` preferred, then `safety`):
+
+```bash
+# pip-audit
+pip-audit --format json 2>/dev/null
+
+# safety (legacy)
+safety check --json 2>/dev/null
+```
+
+Parse JSON output. Record package, installed version, vulnerability ID (CVE or PYSEC), and description.
+
+**Fallback** — use `pip list --format json` (or parse `requirements*.txt` / `Pipfile.lock` / `poetry.lock`) to enumerate installed packages. Note that no vulnerability check could be performed and list all packages for manual review.
+
+### Ruby (bundler)
+
+**Tool available** (`bundler-audit`):
+
+```bash
+bundle-audit check --format json 2>/dev/null || bundle audit check 2>/dev/null
+```
+
+**Fallback** — parse `Gemfile.lock` for gem names and versions and list them for manual review.
+
+### Go (go modules)
+
+**Tool available** (`govulncheck`):
+
+```bash
+govulncheck ./... 2>/dev/null
+```
+
+**Fallback** — parse `go.sum` or `go.mod` for module paths and versions. Attempt `go list -m -u all 2>/dev/null` to detect available updates.
+
+### Java (Maven / Gradle)
+
+**Tool available**:
+
+```bash
+# Maven OWASP dependency-check plugin (if wrapper present)
+./mvnw dependency-check:check -DfailBuildOnCVSS=0 2>/dev/null \
+  || mvn dependency-check:check -DfailBuildOnCVSS=0 2>/dev/null
+
+# Gradle (if wrapper present)
+./gradlew dependencyCheckAnalyze 2>/dev/null \
+  || gradle dependencyCheckAnalyze 2>/dev/null
+```
+
+**Fallback** — parse `pom.xml` or `build.gradle` for declared dependency coordinates and list them for manual review.
+
+### PHP (Composer)
+
+**Tool available** (`local-php-security-checker` or `composer audit`):
+
+```bash
+composer audit --format json 2>/dev/null \
+  || local-php-security-checker 2>/dev/null
+```
+
+**Fallback** — parse `composer.lock` for package names and versions and list them for manual review.
+
+---
+
+## Phase 3 — Check for Outdated Packages
+
+For each ecosystem where an "outdated" check is cheap and non-destructive, run it.
+
+### Node.js
+
+```bash
+npm outdated --json 2>/dev/null
+# or
+yarn outdated --json 2>/dev/null
+```
+
+Record: package, current, wanted (latest compatible per semver), latest.
+
+### Rust
+
+```bash
+cargo outdated --format json 2>/dev/null
+```
+
+If `cargo-outdated` is not installed, skip — do not attempt to install it.
+
+### Python
+
+```bash
+pip list --outdated --format json 2>/dev/null
+```
+
+### Ruby
+
+```bash
+bundle outdated --parseable 2>/dev/null
+```
+
+### Go
+
+```bash
+go list -m -u all 2>/dev/null
+```
+
+Parse lines with `[v...]` indicating available updates.
+
+### Java / PHP
+
+Skip outdated checks — these ecosystems do not have a cheap single-command equivalent. Note the omission in the report.
+
+---
+
+## Phase 4 — Consolidate and Rank Findings
+
+Merge vulnerability and outdated results across all ecosystems.
+
+### Severity ranking (high to low)
+
+1. **Critical** — CVSS ≥ 9.0 or tool-reported `critical`
+2. **High** — CVSS 7.0–8.9 or tool-reported `high`
+3. **Moderate / Medium** — CVSS 4.0–6.9
+4. **Low** — CVSS < 4.0
+5. **Outdated (no CVE)** — newer version available but no known vulnerability
+
+Deduplicate: if the same package appears in both vulnerability and outdated lists, merge into one entry (mark it as both vulnerable AND outdated).
+
+---
+
+## Phase 5 — Write Report
+
+Print the report to stdout in Markdown. Do **not** write any files.
+
+```
+# Dependency Audit Report
+
+**Date:** YYYY-MM-DD
+**Project:** <root directory name or package.json#name>
+**Ecosystems scanned:** <list>
+**Tools used:** <list of tools that were available; note fallbacks>
+
+---
+
+## Summary
+
+| Severity  | Count |
+|-----------|-------|
+| Critical  | N     |
+| High      | N     |
+| Moderate  | N     |
+| Low       | N     |
+| Outdated  | N     |
+| **Total** | N     |
+
+---
+
+## Vulnerabilities
+
+### Critical
+
+#### <package-name> <version> (<ecosystem>)
+- **Advisory:** <CVE-YYYY-XXXX or RUSTSEC-YYYY-XXXX or GHSA-...>
+- **Description:** <one-line summary>
+- **Fix:** Upgrade to <fixed version> (or: no fix available as of <date>)
+
+... (repeat for each critical finding) ...
+
+### High
+... (same format) ...
+
+### Moderate / Low
+... (same format) ...
+
+---
+
+## Outdated Packages (no known vulnerability)
+
+| Ecosystem | Package | Current | Latest | Notes |
+|-----------|---------|---------|--------|-------|
+| Node.js   | lodash  | 4.17.19 | 4.17.21 | patch — safe to upgrade |
+| ...       | ...     | ...     | ...    | ...   |
+
+---
+
+## Fallbacks and Limitations
+
+List any ecosystem where the dedicated audit tool was unavailable and what fallback (if any) was used. If no check could be performed, say so explicitly.
+
+---
+
+## Recommended Actions
+
+1. **Immediate (Critical/High):** <specific upgrades>
+2. **Scheduled (Moderate/Outdated):** <specific upgrades>
+3. **Manual review:** <any packages where the fallback path was used and results are uncertain>
+```
+
+If no vulnerabilities are found, say so clearly and list the ecosystems that were scanned cleanly.
+
+---
+
+## Rules
+
+- **Read-only.** Never run `npm install`, `cargo update`, `pip install`, `bundle update`, or any command that modifies the project or its lock files.
+- **Graceful degradation.** If a tool is missing, use the fallback and document it. Never abort the skill because one tool is absent.
+- **Monorepo-aware.** Scan every manifest found in Phase 1 — not just the root.
+- **No false positives from dev-only packages.** If the audit tool distinguishes `devDependencies` from production dependencies, note which findings affect production vs. dev-only packages.
+- **Idempotent.** Running the skill twice produces the same report (assuming no upstream changes).

--- a/plugins/dependency-audit/skills/dependency-audit/SKILL.md
+++ b/plugins/dependency-audit/skills/dependency-audit/SKILL.md
@@ -94,7 +94,11 @@ yarn audit --json 2>/dev/null
 pnpm audit --json 2>/dev/null
 ```
 
-Parse the JSON output. For each vulnerability, record:
+Parse the audit output according to the tool's actual format:
+- `npm audit --json` and `pnpm audit --json` emit a single JSON document.
+- `yarn audit --json` in Yarn v1 emits newline-delimited JSON (NDJSON): each line is a separate JSON event, not one top-level JSON document. Parse it line by line (or aggregate the per-line JSON objects first), then extract vulnerability information from the relevant audit/advisory events.
+
+For each vulnerability, record:
 - Package name
 - Installed version
 - Severity (`critical` / `high` / `moderate` / `low` / `info`)

--- a/plugins/dependency-audit/skills/dependency-audit/evals/evals.json
+++ b/plugins/dependency-audit/skills/dependency-audit/evals/evals.json
@@ -34,9 +34,9 @@
     {
       "id": 1,
       "prompt": "Check this Python project for dependency vulnerabilities",
-      "description": "Python project with a requirements.txt listing a package with a known CVE. pip-audit should be invoked if available; otherwise pip list --outdated is used as a fallback. The report must clearly distinguish between the tool path and the fallback path.",
+      "description": "Python project with a requirements.txt listing a package with a known CVE. pip-audit should be invoked against the manifest file (pip-audit -r requirements.txt) if available. If no audit tool is found, the skill must fall back to parsing requirements.txt directly and listing the declared packages for manual review — not running pip list, which reflects the interpreter environment. The report must clearly distinguish between the tool path and the fallback path.",
       "setup": "mkdir -p /tmp/eval-depaudit-1 && cd /tmp/eval-depaudit-1 && git init && cat > requirements.txt << 'EOF'\nrequests==2.18.0\nEOF",
-      "expected_output": "Report identifies the Python ecosystem, states whether pip-audit was used or a fallback was applied, and flags requests 2.18.0 as outdated or vulnerable. If pip-audit is unavailable, the report explicitly states this and lists packages for manual review.",
+      "expected_output": "Report identifies the Python ecosystem, states whether pip-audit was invoked against requirements.txt or a fallback was applied. If pip-audit is available, requests 2.18.0 is flagged as vulnerable (CVE or PYSEC advisory exists). If pip-audit is unavailable, the report explicitly states this, lists requests==2.18.0 from the manifest for manual review, and does not use pip list or the interpreter environment.",
       "files": [],
       "assertions": [
         {

--- a/plugins/dependency-audit/skills/dependency-audit/evals/evals.json
+++ b/plugins/dependency-audit/skills/dependency-audit/evals/evals.json
@@ -1,0 +1,135 @@
+{
+  "skill_name": "dependency-audit",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "Audit the dependencies in this project for vulnerabilities",
+      "description": "Node.js project with a package-lock.json present and npm available. npm audit should be invoked and its output parsed. The report must show the severity breakdown and list at least one advisory.",
+      "setup": "mkdir -p /tmp/eval-depaudit-0 && cd /tmp/eval-depaudit-0 && git init && cat > package.json << 'EOF'\n{\n  \"name\": \"test-app\",\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"lodash\": \"4.17.4\"\n  }\n}\nEOF\nnpm install --package-lock-only 2>/dev/null || true",
+      "expected_output": "Report identifies the Node.js ecosystem, notes that npm audit was used, and lists lodash 4.17.4 as vulnerable (prototype pollution advisories exist for versions below 4.17.21). Report includes severity, advisory ID, and a recommended fix version.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "npm-audit-used",
+          "text": "The report states that npm audit was used to scan dependencies"
+        },
+        {
+          "id": "lodash-flagged",
+          "text": "lodash is listed as a vulnerable package"
+        },
+        {
+          "id": "severity-present",
+          "text": "The report includes a severity level (critical, high, moderate, or low) for the lodash finding"
+        },
+        {
+          "id": "fix-version-present",
+          "text": "The report recommends a fix or upgrade path for the vulnerable package"
+        },
+        {
+          "id": "no-files-modified",
+          "text": "No project files were modified — package.json and package-lock.json are unchanged"
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "Check this Python project for dependency vulnerabilities",
+      "description": "Python project with a requirements.txt listing a package with a known CVE. pip-audit should be invoked if available; otherwise pip list --outdated is used as a fallback. The report must clearly distinguish between the tool path and the fallback path.",
+      "setup": "mkdir -p /tmp/eval-depaudit-1 && cd /tmp/eval-depaudit-1 && git init && cat > requirements.txt << 'EOF'\nrequests==2.18.0\nEOF",
+      "expected_output": "Report identifies the Python ecosystem, states whether pip-audit was used or a fallback was applied, and flags requests 2.18.0 as outdated or vulnerable. If pip-audit is unavailable, the report explicitly states this and lists packages for manual review.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "python-ecosystem-detected",
+          "text": "The report identifies Python as one of the scanned ecosystems"
+        },
+        {
+          "id": "requests-mentioned",
+          "text": "requests 2.18.0 appears in the report (as vulnerable, outdated, or requiring manual review)"
+        },
+        {
+          "id": "tool-or-fallback-noted",
+          "text": "The report states which tool was used (pip-audit, safety) or explicitly notes the fallback path if no tool was found"
+        },
+        {
+          "id": "no-files-modified",
+          "text": "requirements.txt is not modified"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Run a dependency audit",
+      "description": "Monorepo with both a Node.js package.json and a Python requirements.txt at different paths. Both ecosystems must be scanned — the skill must not stop after finding the first manifest.",
+      "setup": "mkdir -p /tmp/eval-depaudit-2/frontend /tmp/eval-depaudit-2/backend && cd /tmp/eval-depaudit-2 && git init && cat > frontend/package.json << 'EOF'\n{\n  \"name\": \"frontend\",\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"react\": \"16.8.0\"\n  }\n}\nEOF\ncat > backend/requirements.txt << 'EOF'\nFlask==1.0.0\nEOF",
+      "expected_output": "Report covers both the Node.js frontend and the Python backend. Summary table shows findings for both ecosystems. Fallback paths are documented if dedicated tools are absent.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "node-ecosystem-scanned",
+          "text": "The report mentions Node.js or npm as a scanned ecosystem"
+        },
+        {
+          "id": "python-ecosystem-scanned",
+          "text": "The report mentions Python as a scanned ecosystem"
+        },
+        {
+          "id": "both-manifests-listed",
+          "text": "Both frontend/package.json and backend/requirements.txt (or their packages) appear in the report"
+        },
+        {
+          "id": "summary-table-present",
+          "text": "The report includes a summary table or section listing finding counts by severity across all ecosystems"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Audit dependencies for vulnerabilities",
+      "description": "Clean project with only a Cargo.toml whose dependencies have no known vulnerabilities. The report must say 'no vulnerabilities found' clearly rather than showing an empty table with no explanation.",
+      "setup": "mkdir -p /tmp/eval-depaudit-3/src && cd /tmp/eval-depaudit-3 && git init && cat > Cargo.toml << 'EOF'\n[package]\nname = \"clean-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nserde = { version = \"1\", features = [\"derive\"] }\nEOF\ncat > src/main.rs << 'EOF'\nfn main() {}\nEOF",
+      "expected_output": "Report identifies the Rust ecosystem, states that cargo audit (or fallback) was run, and clearly states that no vulnerabilities were found. The report does not falsely claim findings.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "rust-ecosystem-detected",
+          "text": "The report identifies Rust as a scanned ecosystem"
+        },
+        {
+          "id": "no-vulnerabilities-stated",
+          "text": "The report explicitly states that no vulnerabilities were found (not just an empty section)"
+        },
+        {
+          "id": "audit-tool-or-fallback-noted",
+          "text": "The report states whether cargo audit was used or a fallback was applied"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Check for outdated packages",
+      "description": "Node.js project where no audit tool reports vulnerabilities but npm outdated shows several packages with newer versions available. The outdated section of the report must be populated even when the vulnerabilities section is empty.",
+      "setup": "mkdir -p /tmp/eval-depaudit-4 && cd /tmp/eval-depaudit-4 && git init && cat > package.json << 'EOF'\n{\n  \"name\": \"old-app\",\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"express\": \"4.16.0\",\n    \"chalk\": \"4.0.0\"\n  }\n}\nEOF\nnpm install --package-lock-only 2>/dev/null || true",
+      "expected_output": "Report runs npm outdated and lists express and/or chalk as having newer versions available. The vulnerabilities section is either empty or minimal. The outdated section is not omitted just because no CVEs were found.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "outdated-check-run",
+          "text": "The report includes an outdated packages section (not just vulnerabilities)"
+        },
+        {
+          "id": "outdated-packages-listed",
+          "text": "At least one package is listed as having a newer version available"
+        },
+        {
+          "id": "current-and-latest-shown",
+          "text": "The report shows both the currently installed version and the available latest version for outdated packages"
+        },
+        {
+          "id": "no-files-modified",
+          "text": "package.json and lock files are not modified"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a new **dependency-audit** skill plugin that scans all dependency manifests for known security vulnerabilities and outdated packages.

- Supports **Node.js** (npm/yarn/pnpm audit + npm outdated), **Python** (pip-audit/safety + pip list --outdated), **Rust** (cargo audit + cargo-outdated), **Ruby** (bundler-audit), **Go** (govulncheck + go list -m -u), **Java** (Maven/Gradle OWASP plugin), and **PHP** (composer audit)
- Gracefully degrades to grep-based fallbacks when dedicated audit tools are absent, always documenting which path was used
- Monorepo-aware: scans every manifest found up to 3 levels deep (not just the root)
- Read-only: never modifies lock files, manifests, or any project file
- Ships with 5 evals covering happy path, clean projects (no findings), monorepos, outdated-only findings, and explicit fallback documentation

---
*Opened by multi-repo-tasks via Claude Code.*