### PR TITLE
feat(auto-board-task): add copilot-review-fixer as step 4 in workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "auto-board-task",
       "source": "./plugins/auto-board-task",
-      "description": "Process the top Todo card on a GitHub Project (v2) board end-to-end: pull the board into a task-agent tasks.yml, run task-agent against the top pending task to open a PR, then sync the PR back so the card moves to In Review. Bundles the `gh-project-sync` reconciler skill (used twice in the chain) and composes it with `task-agent` via the `workflow` skill — both `task-agent` and `workflow` must also be installed.",
+      "description": "Process the top Todo card on a GitHub Project (v2) board end-to-end: pull the board into a task-agent tasks.yml, run task-agent against the top pending task to open a PR, sync the PR back so the card moves to In Review, then apply fixes for actionable Copilot review comments. Bundles the `gh-project-sync` reconciler skill (used twice in the chain) and composes it with `task-agent` and `copilot-review-fixer` via the `workflow` skill — `task-agent` and `workflow` must also be installed.",
       "category": "automation",
       "homepage": "https://github.com/dan323/easier-life-skills/tree/master/plugins/auto-board-task"
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "auto-board-task",
       "source": "./plugins/auto-board-task",
-      "description": "Process the top Todo card on a GitHub Project (v2) board end-to-end: pull the board into a task-agent tasks.yml, run task-agent against the top pending task to open a PR, sync the PR back so the card moves to In Review, then apply fixes for actionable Copilot review comments. Bundles the `gh-project-sync` reconciler skill (used twice in the chain) and composes it with `task-agent` and `copilot-review-fixer` via the `workflow` skill — `task-agent` and `workflow` must also be installed.",
+      "description": "Process the top Todo card on a GitHub Project (v2) board end-to-end: pull the board into a task-agent tasks.yml, run task-agent against the top pending task to open a PR, sync the PR back so the card moves to In Review, then apply fixes for actionable Copilot review comments. Bundles the `gh-project-sync` reconciler skill (used twice in the chain) and composes it with `task-agent` and the `copilot-review-fixer` skill wrapper (shipped by `task-agent`) via the `workflow` skill — `task-agent` and `workflow` must also be installed.",
       "category": "automation",
       "homepage": "https://github.com/dan323/easier-life-skills/tree/master/plugins/auto-board-task"
     },
@@ -85,7 +85,7 @@
     {
       "name": "task-agent",
       "source": "./plugins/task-agent",
-      "description": "Read tasks from a YAML file (unified or legacy two-file format), implement one per run via an agent, and open a PR",
+      "description": "Read tasks from a YAML file (unified or legacy two-file format), implement one per run via an agent, and open a PR. Also ships a `copilot-review-fixer` skill callable as a workflow step.",
       "category": "automation",
       "homepage": "https://github.com/dan323/easier-life-skills/tree/master/plugins/task-agent"
     },

--- a/plugins/auto-board-task/.claude-plugin/plugin.json
+++ b/plugins/auto-board-task/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-board-task",
-  "version": "1.1.4",
-  "description": "Process the top Todo card on a GitHub Project (v2) board end-to-end: pull the board into a task-agent tasks.yml, run task-agent against the top pending task to open a PR, then sync the PR back so the card moves to In Review. Bundles the `gh-project-sync` reconciler skill (used twice in the chain) and composes it with `task-agent` via the `workflow` skill — both `task-agent` and `workflow` must also be installed.",
+  "version": "1.2.0",
+  "description": "Process the top Todo card on a GitHub Project (v2) board end-to-end: pull the board into a task-agent tasks.yml, run task-agent against the top pending task to open a PR, sync the PR back so the card moves to In Review, then apply fixes for actionable Copilot review comments. Bundles the `gh-project-sync` reconciler skill (used twice in the chain) and composes it with `task-agent` and `copilot-review-fixer` via the `workflow` skill — `task-agent` and `workflow` must also be installed.",
   "author": { "name": "dan323" },
   "category": "automation",
   "dependencies": [

--- a/plugins/auto-board-task/.claude-plugin/plugin.json
+++ b/plugins/auto-board-task/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-board-task",
   "version": "1.2.0",
-  "description": "Process the top Todo card on a GitHub Project (v2) board end-to-end: pull the board into a task-agent tasks.yml, run task-agent against the top pending task to open a PR, sync the PR back so the card moves to In Review, then apply fixes for actionable Copilot review comments. Bundles the `gh-project-sync` reconciler skill (used twice in the chain) and composes it with `task-agent` and `copilot-review-fixer` via the `workflow` skill — `task-agent` and `workflow` must also be installed.",
+  "description": "Process the top Todo card on a GitHub Project (v2) board end-to-end: pull the board into a task-agent tasks.yml, run task-agent against the top pending task to open a PR, sync the PR back so the card moves to In Review, then apply fixes for actionable Copilot review comments. Bundles the `gh-project-sync` reconciler skill (used twice in the chain) and composes it with `task-agent` and the `copilot-review-fixer` skill wrapper (shipped by `task-agent`) via the `workflow` skill — `task-agent` and `workflow` must also be installed.",
   "author": { "name": "dan323" },
   "category": "automation",
   "dependencies": [

--- a/plugins/auto-board-task/skills/auto-board-task/SKILL.md
+++ b/plugins/auto-board-task/skills/auto-board-task/SKILL.md
@@ -3,16 +3,18 @@ name: auto-board-task
 description: >
   Process the top Todo card on a GitHub Project (v2) board end-to-end:
   pull the board into a task-agent `tasks.yml`, run `task-agent` to
-  open a PR for the top pending task, then sync the PR back to the
-  card. Use when the user says "work on the next task", "do the next
-  board task", "pick up the next GitHub project item", "process the
-  next card", "work on the next item in github project", "run the
-  next board task", "drain the top todo", "process the top board
-  todo", "auto-process the next card", or any phrasing that means
-  "take the next pending item from a GitHub Project board and
-  implement it". Composes `gh-project-sync` → `task-agent` →
-  `gh-project-sync` via the `workflow` skill against the fixed YAML
-  at `${CLAUDE_PLUGIN_ROOT}/workflows/auto-board-task.yaml`. All
+  open a PR for the top pending task, sync the PR back to the card,
+  then wait for Copilot to review the PR and apply fixes for
+  actionable comments. Use when the user says "work on the next
+  task", "do the next board task", "pick up the next GitHub project
+  item", "process the next card", "work on the next item in github
+  project", "run the next board task", "drain the top todo", "process
+  the top board todo", "auto-process the next card", or any phrasing
+  that means "take the next pending item from a GitHub Project board
+  and implement it". Composes `gh-project-sync` → `task-agent` →
+  `gh-project-sync` → `copilot-review-fixer` via the `workflow`
+  skill against the fixed YAML at
+  `${CLAUDE_PLUGIN_ROOT}/workflows/auto-board-task.yaml`. All
   arguments are forwarded verbatim to the workflow runner;
   validation happens there and inside the composed sub-skills.
 tools: Bash
@@ -30,6 +32,7 @@ The workflow chains:
 1. `gh-project-sync` — reconcile the board into `tasks.yml`.
 2. `task-agent` — open a PR for the top pending task.
 3. `gh-project-sync` — sync the PR back to its card.
+4. `copilot-review-fixer` — wait for Copilot's review, then fix actionable comments.
 
 ## What to do
 

--- a/plugins/auto-board-task/skills/auto-board-task/SKILL.md
+++ b/plugins/auto-board-task/skills/auto-board-task/SKILL.md
@@ -12,8 +12,8 @@ description: >
   the top board todo", "auto-process the next card", or any phrasing
   that means "take the next pending item from a GitHub Project board
   and implement it". Composes `gh-project-sync` → `task-agent` →
-  `gh-project-sync` → `copilot-review-fixer` via the `workflow`
-  skill against the fixed YAML at
+  `gh-project-sync` → `copilot-review-fixer` (skill wrapper shipped
+  by `task-agent`) via the `workflow` skill against the fixed YAML at
   `${CLAUDE_PLUGIN_ROOT}/workflows/auto-board-task.yaml`. All
   arguments are forwarded verbatim to the workflow runner;
   validation happens there and inside the composed sub-skills.

--- a/plugins/auto-board-task/workflows/auto-board-task.yaml
+++ b/plugins/auto-board-task/workflows/auto-board-task.yaml
@@ -2,24 +2,29 @@
 #
 # Processes the top Todo card on a GitHub Project (v2) board end-to-end:
 #
-#   1. gh-project-sync  — reconcile the board into `tasks.yml`. New Todo
-#                         cards land as `status: pending`; stale Done /
-#                         Won't Do entries are dropped.
-#   2. task-agent       — pick the first pending task in `tasks.yml`
-#                         (i.e. the top of the Todo column after step 1),
-#                         clone the repo, do the work, open a PR, and mark
-#                         the entry `status: done` with a `pr_url`.
-#   3. gh-project-sync  — reconcile again. Rule 4 fires for the entry
-#                         freshly marked `done + pr_url`: the card moves
-#                         to In Review (or In Progress if the board has
-#                         no In Review column) and the PR link is posted
-#                         as a comment on the card.
+#   1. gh-project-sync       — reconcile the board into `tasks.yml`. New Todo
+#                              cards land as `status: pending`; stale Done /
+#                              Won't Do entries are dropped.
+#   2. task-agent            — pick the first pending task in `tasks.yml`
+#                              (i.e. the top of the Todo column after step 1),
+#                              clone the repo, do the work, open a PR, and mark
+#                              the entry `status: done` with a `pr_url`.
+#   3. gh-project-sync       — reconcile again. Rule 4 fires for the entry
+#                              freshly marked `done + pr_url`: the card moves
+#                              to In Review (or In Progress if the board has
+#                              no In Review column) and the PR link is posted
+#                              as a comment on the card.
+#   4. copilot-review-fixer  — waits for Copilot to post review comments on
+#                              the new PR, then applies fixes for actionable
+#                              ones. Runs at the workflow level so the Agent
+#                              tool is available (subagents cannot spawn
+#                              further agents).
 #
 # See ../skills/auto-board-task/SKILL.md for the user-facing flow,
 # and ../../workflow/references/format.md for the workflow YAML schema.
 
 name: auto-board-task
-description: Drain the top Todo card from a GitHub Project — sync in, run task-agent, sync out.
+description: Drain the top Todo card from a GitHub Project — sync in, run task-agent, sync out, fix Copilot review comments.
 category: automation
 
 inputs:
@@ -61,3 +66,11 @@ steps:
       project_owner: ${{ inputs.project_owner }}
       project_number: ${{ inputs.project_number }}
       default_repo: ${{ inputs.default_repo }}
+
+  - id: review-fix
+    skill: copilot-review-fixer
+    description: Wait for Copilot to review the PR, then apply fixes for actionable comments.
+    args:
+      pr_url: ${{ steps.run-task.output.pr_url }}
+      repo: ${{ steps.run-task.output.repo }}
+      branch: ${{ steps.run-task.output.branch }}

--- a/plugins/task-agent/.claude-plugin/plugin.json
+++ b/plugins/task-agent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-agent",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read tasks from a YAML file (unified or legacy two-file format), implement one per run via an agent, and open a PR",
   "author": { "name": "dan323" },
   "category": "automation",

--- a/plugins/task-agent/.claude-plugin/plugin.json
+++ b/plugins/task-agent/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "task-agent",
-  "version": "1.1.1",
-  "description": "Read tasks from a YAML file (unified or legacy two-file format), implement one per run via an agent, and open a PR",
+  "version": "1.2.0",
+  "description": "Read tasks from a YAML file (unified or legacy two-file format), implement one per run via an agent, and open a PR. Also ships a `copilot-review-fixer` skill callable as a workflow step.",
   "author": { "name": "dan323" },
   "category": "automation",
-  "skills": ["./skills/task-agent"]
+  "skills": ["./skills/task-agent", "./skills/copilot-review-fixer"]
 }

--- a/plugins/task-agent/skills/copilot-review-fixer/SKILL.md
+++ b/plugins/task-agent/skills/copilot-review-fixer/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: copilot-review-fixer
+description: Reads unresolved Copilot review comments on a pull request and applies code fixes for actionable ones. Thin skill wrapper around the `copilot-review-fixer` sub-agent — callable as a workflow step.
+tools: Bash, PowerShell, Read, Edit, Glob, Grep, Agent, mcp__github__pull_request_read
+---
+
+# Copilot Review Fixer
+
+Wraps the `task-agent:copilot-review-fixer` sub-agent so it can be invoked as a workflow step.
+
+**Arguments** (key=value form):
+- `pr_url=<url>` — full GitHub PR URL (e.g. `https://github.com/owner/repo/pull/42`). Required.
+- `repo=<owner/repo>` — repository in `owner/repo` format. Required.
+- `branch=<branch>` — branch name the PR is on. Required.
+
+## What to do
+
+### Step 1 — Parse arguments
+
+Parse `pr_url`, `repo`, and `branch` from the invocation arguments.
+
+Derive:
+- `OWNER` and `REPO_NAME` from `repo` (split on `/`)
+- `PR_NUMBER` from the last path segment of `pr_url`
+
+If any required argument is missing or cannot be parsed, stop and report the error clearly.
+
+### Step 2 — Prepare the local clone
+
+Reuse the `task-agent` workdir convention so the clone is shared with a preceding `task-agent` step in the same workflow:
+
+```bash
+WORKDIR="${TASK_AGENT_WORKDIR:-$(python3 -c 'import os,tempfile;print(os.path.join(tempfile.gettempdir(),"task-agent"))')}"
+LOCAL_PATH="$WORKDIR/$REPO_NAME"
+if [ -d "$LOCAL_PATH/.git" ]; then
+  git -C "$LOCAL_PATH" fetch origin
+  git -C "$LOCAL_PATH" checkout "$BRANCH"
+  git -C "$LOCAL_PATH" reset --hard "origin/$BRANCH"
+else
+  mkdir -p "$WORKDIR"
+  git clone "https://github.com/$OWNER/$REPO_NAME.git" "$LOCAL_PATH"
+  git -C "$LOCAL_PATH" checkout "$BRANCH"
+fi
+```
+
+Detect the default branch:
+
+```bash
+DEFAULT_BRANCH=$(git -C "$LOCAL_PATH" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+```
+
+### Step 3 — Spawn the sub-agent
+
+Spawn the `copilot-review-fixer` sub-agent via the `Agent` tool
+(`subagent_type: task-agent:copilot-review-fixer`), passing all resolved values in the
+prompt so the agent can substitute them for `OWNER`, `REPO_NAME`, `PR_NUMBER`, `BRANCH`,
+`LOCAL_PATH`, and `DEFAULT_BRANCH`.

--- a/plugins/task-agent/skills/copilot-review-fixer/evals/evals.json
+++ b/plugins/task-agent/skills/copilot-review-fixer/evals/evals.json
@@ -1,0 +1,1 @@
+{"skill_name":"copilot-review-fixer","evals":[]}

--- a/plugins/task-agent/skills/task-agent/SKILL.md
+++ b/plugins/task-agent/skills/task-agent/SKILL.md
@@ -202,9 +202,7 @@ Call `mcp__github__create_pull_request` with:
 Capture the `html_url` field from the response as the PR URL.
 Extract the PR number from the URL (last path segment).
 
-Immediately after the PR is open, **spawn Phase 5 in the background** (run_in_background: true),
-passing it: OWNER, REPO_NAME, PR_NUMBER, BRANCH, LOCAL_PATH, DEFAULT_BRANCH.
-Then continue to Phase 4 without waiting for Phase 5 to finish.
+After the PR is open, continue to Phase 4.
 
 ---
 
@@ -272,8 +270,7 @@ Next up:  "Fix the typo in README.md" (owner/repo-name)
 
 ## Phase 5 — Remove all temporary files
 
-After all tasks are done, spawn an agent to clean up the local clones in `$WORKDIR` to
-free up disk space:
+After all tasks are done, run the cleanup directly:
 
 ```bash
 rm -rf "$WORKDIR"

--- a/plugins/task-agent/skills/task-agent/SKILL.md
+++ b/plugins/task-agent/skills/task-agent/SKILL.md
@@ -270,27 +270,7 @@ Next up:  "Fix the typo in README.md" (owner/repo-name)
 
 ---
 
-## Phase 5 — Review and fix Copilot comments (background)
-
-This phase runs **in the background**, in parallel with Phase 4.
-Spawn it as a background agent immediately after the PR is opened.
-
-Spawn a background agent using the Agent tool with:
-- `subagent_type`: `task-agent:copilot-review-fixer`
-- `run_in_background`: `true`
-- `prompt`: the real values for the placeholders, e.g.:
-  ```
-  OWNER=<owner>
-  REPO_NAME=<repo>
-  PR_NUMBER=<number>
-  BRANCH=<branch>
-  LOCAL_PATH=<path>
-  DEFAULT_BRANCH=<branch>
-  ```
-
----
-
-## Phase 6 — Remove all temporary files
+## Phase 5 — Remove all temporary files
 
 After all tasks are done, spawn an agent to clean up the local clones in `$WORKDIR` to
 free up disk space:

--- a/plugins/task-agent/skills/task-agent/SKILL.md
+++ b/plugins/task-agent/skills/task-agent/SKILL.md
@@ -247,7 +247,22 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/tasks_io.py" record "$TASKS_PATH" \
 `{"branch": "...", "pr_url": "...", "date": "YYYY-MM-DD"}`; for `failed` use
 `{"error": "<short reason>"}`; for `skipped` use `{"reason": "<why>"}`.
 
-### 4.3 Print the summary
+### 4.3 Emit workflow output
+
+If the `$WORKFLOW_OUTPUT` environment variable is set (i.e. this skill is running as a
+workflow step), write a JSON object so the next step can interpolate `pr_url`, `repo`,
+and `branch`:
+
+```bash
+if [ -n "$WORKFLOW_OUTPUT" ]; then
+  printf '{"pr_url":"%s","repo":"%s/%s","branch":"%s"}' \
+    "$PR_URL" "$OWNER" "$REPO_NAME" "$BRANCH" > "$WORKFLOW_OUTPUT"
+fi
+```
+
+Skip this step when `$WORKFLOW_OUTPUT` is unset (standalone invocation).
+
+### 4.4 Print the summary
 
 ```
 ## Task — Done


### PR DESCRIPTION
## Summary

- Adds a `review-fix` step to `auto-board-task.yaml` that runs `copilot-review-fixer` after the board sync-out step
- Passes `pr_url`, `repo`, and `branch` from the `run-task` step output via `${{ steps.run-task.output.* }}` expressions
- Fixes the silent skip that occurred because subagents spawned inside `task-agent` cannot use the `Agent` tool — running it as an explicit top-level workflow step gives it the required tool access
- Bumps `auto-board-task` plugin to v1.2.0

## Test plan

- [ ] Run `/auto-board-task` against project 4 and confirm a 4th `review-fix` step appears in the workflow output
- [ ] Confirm Copilot review comments are processed and fixes are applied on the resulting PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)