### PR TITLE
[Phase 2] Extend act to track entities and failures

### DIFF
--- a/badge.svg
+++ b/badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="151" height="20" viewBox="0 0 151 20" role="img" aria-label="Claude Code: 71 skills">
-  <title>Claude Code: 71 skills</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="151" height="20" viewBox="0 0 151 20" role="img" aria-label="Claude Code: 56 skills">
+  <title>Claude Code: 56 skills</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,7 +13,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     <text aria-hidden="true" x="410" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="715" lengthAdjust="spacing">Claude Code</text>
     <text x="410" y="140" transform="scale(.1)" textLength="715" lengthAdjust="spacing">Claude Code</text>
-    <text aria-hidden="true" x="1170" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="585" lengthAdjust="spacing">71 skills</text>
-    <text x="1170" y="140" transform="scale(.1)" textLength="585" lengthAdjust="spacing">71 skills</text>
+    <text aria-hidden="true" x="1170" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="585" lengthAdjust="spacing">56 skills</text>
+    <text x="1170" y="140" transform="scale(.1)" textLength="585" lengthAdjust="spacing">56 skills</text>
   </g>
 </svg>

--- a/plugins/memplan/skills/act/SKILL.md
+++ b/plugins/memplan/skills/act/SKILL.md
@@ -100,13 +100,23 @@ node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" append . memory/code-map.mem "file
 
 **Record new entities discovered:**
 
-For each new concept, symbol, or module encountered that is not already in `entities.mem`:
+For each new concept, symbol, or module encountered during the step, check whether it is
+already recorded before appending. Skip if already present:
+
+```bash
+grep "name=<name>" .memplan/memory/entities.mem 2>/dev/null
+```
+
+If the grep returns no output (entity not found), append it:
 
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" append . memory/entities.mem "entity" "name=<name>,type=<type>,desc=<description>"
 ```
 
 Types: `file`, `function`, `class`, `module`, `config`, `concept`.
+
+Do **not** append an entity whose `name=` value already appears in `entities.mem` — even
+if the description differs. This prevents duplicate entries across re-runs.
 
 **Record failure (if step failed):**
 

--- a/plugins/memplan/skills/act/SKILL.md
+++ b/plugins/memplan/skills/act/SKILL.md
@@ -104,16 +104,15 @@ For each new concept, symbol, or module encountered during the step, check wheth
 already recorded before appending. Skip if already present:
 
 ```bash
-grep "name=<name>" .memplan/memory/entities.mem 2>/dev/null
-```
-
-If the grep returns no output (entity not found), append it:
-
-```bash
-node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" append . memory/entities.mem "entity" "name=<name>,type=<type>,desc=<description>"
+if ! grep -qF "name=<name>," .memplan/memory/entities.mem 2>/dev/null; then
+  node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" append . memory/entities.mem "entity" "name=<name>,type=<type>,desc=<description>"
+fi
 ```
 
 Types: `file`, `function`, `class`, `module`, `config`, `concept`.
+
+The `-F` flag ensures fixed-string matching (no regex), and the trailing comma after
+`name=<name>,` prevents false matches (e.g., `name=Router,` will not match `name=Router2,`).
 
 Do **not** append an entity whose `name=` value already appears in `entities.mem` — even
 if the description differs. This prevents duplicate entries across re-runs.

--- a/plugins/memplan/skills/act/evals/evals.json
+++ b/plugins/memplan/skills/act/evals/evals.json
@@ -61,8 +61,8 @@
     },
     {
       "id": 3,
-      "prompt": "Execute step 1 of the plan. The step creates a file called router.js and introduces a 'Router' class.",
-      "description": "Entity dedup: the agent runs act twice for the same step. The second run must not produce a duplicate entity entry for 'Router'.",
+      "prompt": "Execute step 1 of the plan. The step creates a file called router.js and introduces a 'Router' class. entities.mem already contains an entry with name=Router.",
+      "description": "Entity dedup: when the entity already exists in entities.mem, act must not append a duplicate entry for 'Router'.",
       "setup": "mkdir -p /tmp/eval-act-3/.memplan/memory /tmp/eval-act-3/.memplan/decisions /tmp/eval-act-3/.memplan/inbox && echo '0/2 | not-started' > /tmp/eval-act-3/.memplan/progress && printf '+step:id=1,text=create-router,atomic=true\\n+step:id=2,text=write-tests,deps=1,atomic=true\\n' > /tmp/eval-act-3/.memplan/steps.mem && printf '2024-01-01T00:00Z +entity:name=Router,type=class,desc=HTTP router\\n' > /tmp/eval-act-3/.memplan/memory/entities.mem && touch /tmp/eval-act-3/.memplan/memory/code-map.mem /tmp/eval-act-3/.memplan/memory/failures.mem && printf '' > /tmp/eval-act-3/.memplan/stale.mem && printf '' > /tmp/eval-act-3/.memplan/deps.mem && printf '' > /tmp/eval-act-3/.memplan/deps-closure.mem && touch /tmp/eval-act-3/router.js",
       "expected_output": "Step 1 completes. entities.mem contains exactly one entry for 'Router' — the pre-existing entry is not duplicated.",
       "files": [],

--- a/plugins/memplan/skills/act/evals/evals.json
+++ b/plugins/memplan/skills/act/evals/evals.json
@@ -79,10 +79,10 @@
     },
     {
       "id": 4,
-      "prompt": "Execute step 1 of the plan. The step runs a failing build command.",
+      "prompt": "Execute step 1 of the plan. The step runs a failing build command (run ./fail-build.sh, which exits non-zero).",
       "description": "Failure recording: when a step fails, the failure must be appended to failures.mem with both cmd and reason fields present.",
-      "setup": "mkdir -p /tmp/eval-act-4/.memplan/memory /tmp/eval-act-4/.memplan/decisions /tmp/eval-act-4/.memplan/inbox && echo '0/2 | not-started' > /tmp/eval-act-4/.memplan/progress && printf '+step:id=1,text=run-build,atomic=true\\n+step:id=2,text=deploy,deps=1,atomic=true\\n' > /tmp/eval-act-4/.memplan/steps.mem && touch /tmp/eval-act-4/.memplan/memory/code-map.mem /tmp/eval-act-4/.memplan/memory/entities.mem /tmp/eval-act-4/.memplan/memory/failures.mem && printf '' > /tmp/eval-act-4/.memplan/stale.mem && printf '' > /tmp/eval-act-4/.memplan/deps.mem && printf '' > /tmp/eval-act-4/.memplan/deps-closure.mem",
-      "expected_output": "Step 1 fails (e.g. 'npm run build' exits non-zero). failures.mem contains one entry with a 'cmd=' field and a 'reason=' field describing the failure. The skill prints 'Step 1 failed — failure recorded. Resolve before retrying.'",
+      "setup": "mkdir -p /tmp/eval-act-4/.memplan/memory /tmp/eval-act-4/.memplan/decisions /tmp/eval-act-4/.memplan/inbox && echo '0/2 | not-started' > /tmp/eval-act-4/.memplan/progress && printf '+step:id=1,text=run-build,atomic=true\\n+step:id=2,text=deploy,deps=1,atomic=true\\n' > /tmp/eval-act-4/.memplan/steps.mem && touch /tmp/eval-act-4/.memplan/memory/code-map.mem /tmp/eval-act-4/.memplan/memory/entities.mem /tmp/eval-act-4/.memplan/memory/failures.mem && printf '' > /tmp/eval-act-4/.memplan/stale.mem && printf '' > /tmp/eval-act-4/.memplan/deps.mem && printf '' > /tmp/eval-act-4/.memplan/deps-closure.mem && printf '#!/usr/bin/env bash\\nexit 1\\n' > /tmp/eval-act-4/fail-build.sh && chmod +x /tmp/eval-act-4/fail-build.sh",
+      "expected_output": "Step 1 fails (./fail-build.sh exits non-zero). failures.mem contains one entry with a 'cmd=' field and a 'reason=' field describing the failure. The skill prints 'Step 1 failed — failure recorded. Resolve before retrying.'",
       "files": [],
       "assertions": [
         {

--- a/plugins/memplan/skills/act/evals/evals.json
+++ b/plugins/memplan/skills/act/evals/evals.json
@@ -58,6 +58,46 @@
           "text": "No files outside .memplan/ are created or modified"
         }
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Execute step 1 of the plan. The step creates a file called router.js and introduces a 'Router' class.",
+      "description": "Entity dedup: the agent runs act twice for the same step. The second run must not produce a duplicate entity entry for 'Router'.",
+      "setup": "mkdir -p /tmp/eval-act-3/.memplan/memory /tmp/eval-act-3/.memplan/decisions /tmp/eval-act-3/.memplan/inbox && echo '0/2 | not-started' > /tmp/eval-act-3/.memplan/progress && printf '+step:id=1,text=create-router,atomic=true\\n+step:id=2,text=write-tests,deps=1,atomic=true\\n' > /tmp/eval-act-3/.memplan/steps.mem && printf '2024-01-01T00:00Z +entity:name=Router,type=class,desc=HTTP router\\n' > /tmp/eval-act-3/.memplan/memory/entities.mem && touch /tmp/eval-act-3/.memplan/memory/code-map.mem /tmp/eval-act-3/.memplan/memory/failures.mem && printf '' > /tmp/eval-act-3/.memplan/stale.mem && printf '' > /tmp/eval-act-3/.memplan/deps.mem && printf '' > /tmp/eval-act-3/.memplan/deps-closure.mem && touch /tmp/eval-act-3/router.js",
+      "expected_output": "Step 1 completes. entities.mem contains exactly one entry for 'Router' — the pre-existing entry is not duplicated.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "entity-not-duplicated",
+          "text": "entities.mem contains exactly one line matching 'name=Router' — the agent checked before appending and skipped the duplicate"
+        },
+        {
+          "id": "progress-updated",
+          "text": ".memplan/progress shows step 1 as complete (e.g. '1/2')"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Execute step 1 of the plan. The step runs a failing build command.",
+      "description": "Failure recording: when a step fails, the failure must be appended to failures.mem with both cmd and reason fields present.",
+      "setup": "mkdir -p /tmp/eval-act-4/.memplan/memory /tmp/eval-act-4/.memplan/decisions /tmp/eval-act-4/.memplan/inbox && echo '0/2 | not-started' > /tmp/eval-act-4/.memplan/progress && printf '+step:id=1,text=run-build,atomic=true\\n+step:id=2,text=deploy,deps=1,atomic=true\\n' > /tmp/eval-act-4/.memplan/steps.mem && touch /tmp/eval-act-4/.memplan/memory/code-map.mem /tmp/eval-act-4/.memplan/memory/entities.mem /tmp/eval-act-4/.memplan/memory/failures.mem && printf '' > /tmp/eval-act-4/.memplan/stale.mem && printf '' > /tmp/eval-act-4/.memplan/deps.mem && printf '' > /tmp/eval-act-4/.memplan/deps-closure.mem",
+      "expected_output": "Step 1 fails (e.g. 'npm run build' exits non-zero). failures.mem contains one entry with a 'cmd=' field and a 'reason=' field describing the failure. The skill prints 'Step 1 failed — failure recorded. Resolve before retrying.'",
+      "files": [],
+      "assertions": [
+        {
+          "id": "failure-recorded",
+          "text": "failures.mem contains an entry with both 'cmd=' and 'reason=' fields"
+        },
+        {
+          "id": "failure-halt-message",
+          "text": "Output contains 'Step 1 failed — failure recorded. Resolve before retrying.'"
+        },
+        {
+          "id": "progress-not-advanced",
+          "text": ".memplan/progress still shows '0/2' — progress is not advanced when the step fails"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a grep-based deduplication guard to the entity recording section of `memplan/act` SKILL.md: the agent checks `entities.mem` before appending, skipping any entity whose `name=` already exists.
- Ensures the failure recording section remains complete with `cmd=` and `reason=` fields.
- Adds two new evals (id=3 entity-dedup, id=4 failure-recording) covering the acceptance criteria from issue #68.

## Test plan

- [ ] Eval id=3: run act twice for a step that introduces a `Router` class — `entities.mem` should contain exactly one `name=Router` entry.
- [ ] Eval id=4: run act for a step whose command fails — `failures.mem` should contain an entry with both `cmd=` and `reason=` fields, and progress should not advance.
- [ ] Existing evals (id=0..2) continue to pass.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)