### PR TITLE
[Phase 2] Extend record to persist aliases and facts

### DIFF
--- a/plugins/memplan/.claude-plugin/plugin.json
+++ b/plugins/memplan/.claude-plugin/plugin.json
@@ -1,7 +1,10 @@
 {
   "name": "memplan",
+  "version": "0.1.0",
   "description": "Persistent low-token working memory and structured planning for Claude Code",
-  "author": { "name": "dan323" },
+  "author": {
+    "name": "dan323"
+  },
   "category": "productivity",
   "skills": [
     "./skills/init",

--- a/plugins/memplan/skills/record/SKILL.md
+++ b/plugins/memplan/skills/record/SKILL.md
@@ -104,21 +104,23 @@ recorded, leave the risk file in place.
 
 For each new alias or fact the user stated (or that emerged clearly from code):
 
+**Aliases** — `set` replaces the existing key, so it is inherently dedup-safe. Write
+unconditionally:
+
 ```bash
-# Alias: short-form → full meaning
+# Alias: short-form → full meaning (set replaces any existing value for <alias-key>)
 node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" set . memory/aliases.mem "<alias-key>" "<full-meaning>"
-
-# Fact: tagged invariant or constraint
-node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" append . memory/facts.mem "fact" "tag=<tag>,text=<text>"
 ```
 
-Skip if no new aliases or facts were discovered. Do not duplicate existing entries — grep
-`aliases.mem` and `facts.mem` first:
+**Facts** — `append` does not dedup, so grep before writing. Skip the fact if the
+identical tag+text pair already exists:
 
 ```bash
-grep "^<alias-key>:" .memplan/memory/aliases.mem 2>/dev/null
-grep "<tag>" .memplan/memory/facts.mem 2>/dev/null
+# Check: skip if this exact tag is already recorded with the same text
+grep "tag=<tag>,text=<text>" .memplan/memory/facts.mem 2>/dev/null ||   node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" append . memory/facts.mem "fact" "tag=<tag>,text=<text>"
 ```
+
+Skip the entire phase if no new aliases or facts were discovered this session.
 
 ---
 

--- a/plugins/memplan/skills/record/SKILL.md
+++ b/plugins/memplan/skills/record/SKILL.md
@@ -116,8 +116,9 @@ node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" set . memory/aliases.mem "<alias-k
 identical tag+text pair already exists:
 
 ```bash
-# Check: skip if this exact tag is already recorded with the same text
-grep "tag=<tag>,text=<text>" .memplan/memory/facts.mem 2>/dev/null ||   node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" append . memory/facts.mem "fact" "tag=<tag>,text=<text>"
+# Check: skip if this exact tag+text pair is already recorded
+grep -Fq "+fact:tag=<tag>,text=<text>" .memplan/memory/facts.mem 2>/dev/null || \
+  node "$CLAUDE_PLUGIN_ROOT/bin/memplan-cli.js" append . memory/facts.mem "fact" "tag=<tag>,text=<text>"
 ```
 
 Skip the entire phase if no new aliases or facts were discovered this session.

--- a/plugins/memplan/skills/record/evals/evals.json
+++ b/plugins/memplan/skills/record/evals/evals.json
@@ -90,12 +90,12 @@
       "prompt": "Record the session. I note that all .plan.md files are read-only. That fact was already recorded last session under tag=plan-files.",
       "description": "Fact dedup: an existing fact tag+text pair is restated. The grep-before-append guard must prevent a second identical entry in facts.mem.",
       "setup": "mkdir -p /tmp/eval-record-4/.memplan/memory /tmp/eval-record-4/.memplan/decisions /tmp/eval-record-4/.memplan/sessions && echo '3/5 | integrate-tests' > /tmp/eval-record-4/.memplan/progress && touch /tmp/eval-record-4/.memplan/checkpoint.mem /tmp/eval-record-4/.memplan/hot.mem /tmp/eval-record-4/.memplan/budget.mem /tmp/eval-record-4/.memplan/memory/aliases.mem /tmp/eval-record-4/.memplan/memory/failures.mem && printf '+fact: tag=plan-files,text=.plan.md files are read-only\n' > /tmp/eval-record-4/.memplan/memory/facts.mem",
-      "expected_output": "facts.mem contains exactly one entry for tag=plan-files. The grep guard detected the existing entry and skipped the append. Checkpoint and session digest are written normally.",
+      "expected_output": "facts.mem contains exactly one entry for tag=plan-files,text=.plan.md files are read-only. The grep guard detected the existing entry and skipped the append. Checkpoint and session digest are written normally.",
       "files": [],
       "assertions": [
         {
           "id": "fact-no-duplicate",
-          "text": ".memplan/memory/facts.mem contains exactly one line with 'tag=plan-files' after the skill runs \u2014 the grep guard prevented a second append"
+          "text": ".memplan/memory/facts.mem contains exactly one line with 'tag=plan-files,text=.plan.md files are read-only' after the skill runs \u2014 the grep guard prevented a second append"
         },
         {
           "id": "checkpoint-written",

--- a/plugins/memplan/skills/record/evals/evals.json
+++ b/plugins/memplan/skills/record/evals/evals.json
@@ -29,7 +29,7 @@
     },
     {
       "id": 1,
-      "prompt": "Record the session. The multi-file change is complete — no failures.",
+      "prompt": "Record the session. The multi-file change is complete \u2014 no failures.",
       "description": "Risk file cleanup: risk.mem present and change completed cleanly. Verifies risk.mem and risk.plan.md are deleted.",
       "setup": "mkdir -p /tmp/eval-record-1/.memplan/memory /tmp/eval-record-1/.memplan/decisions /tmp/eval-record-1/.memplan/sessions && echo '3/3 | complete' > /tmp/eval-record-1/.memplan/progress && printf 'what-could-break:data-loss\\nirreversible:db-drop\\nverify-first:backup\\n' > /tmp/eval-record-1/.memplan/risk.mem && printf '<!-- GENERATED -->\n# Risk\n' > /tmp/eval-record-1/.memplan/risk.plan.md && touch /tmp/eval-record-1/.memplan/checkpoint.mem /tmp/eval-record-1/.memplan/hot.mem /tmp/eval-record-1/.memplan/budget.mem /tmp/eval-record-1/.memplan/memory/aliases.mem /tmp/eval-record-1/.memplan/memory/facts.mem /tmp/eval-record-1/.memplan/memory/failures.mem",
       "expected_output": "risk.mem and risk.plan.md are deleted because the change completed cleanly. Checkpoint and session digest written.",
@@ -54,7 +54,7 @@
       "prompt": "Record the session. I discovered that 'mp' is short for 'memplan' and that all .plan.md files are read-only.",
       "description": "Alias and fact discovery: verifies aliases.mem and facts.mem are updated without creating duplicates.",
       "setup": "mkdir -p /tmp/eval-record-2/.memplan/memory /tmp/eval-record-2/.memplan/decisions /tmp/eval-record-2/.memplan/sessions && echo '1/5 | orient' > /tmp/eval-record-2/.memplan/progress && touch /tmp/eval-record-2/.memplan/checkpoint.mem /tmp/eval-record-2/.memplan/hot.mem /tmp/eval-record-2/.memplan/budget.mem && printf '' > /tmp/eval-record-2/.memplan/memory/aliases.mem && printf '' > /tmp/eval-record-2/.memplan/memory/facts.mem && touch /tmp/eval-record-2/.memplan/memory/failures.mem",
-      "expected_output": "aliases.mem contains an 'mp' → 'memplan' entry. facts.mem contains an entry about plan.md files being read-only. Re-running does not create duplicate entries.",
+      "expected_output": "aliases.mem contains an 'mp' \u2192 'memplan' entry. facts.mem contains an entry about plan.md files being read-only. Re-running does not create duplicate entries.",
       "files": [],
       "assertions": [
         {
@@ -64,6 +64,42 @@
         {
           "id": "fact-written",
           "text": ".memplan/memory/facts.mem contains a +fact: entry about plan.md read-only behaviour"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Record the session. I discovered that 'mp' is short for 'memplan'. The alias 'mp' was already saved last session.",
+      "description": "Alias dedup: an existing alias key is re-stated. The set command must overwrite (not duplicate) the existing key \u2014 aliases.mem must contain exactly one entry for 'mp' after the skill runs.",
+      "setup": "mkdir -p /tmp/eval-record-3/.memplan/memory /tmp/eval-record-3/.memplan/decisions /tmp/eval-record-3/.memplan/sessions && echo '2/5 | write-tests' > /tmp/eval-record-3/.memplan/progress && touch /tmp/eval-record-3/.memplan/checkpoint.mem /tmp/eval-record-3/.memplan/hot.mem /tmp/eval-record-3/.memplan/budget.mem /tmp/eval-record-3/.memplan/memory/failures.mem && printf 'mp: memplan\n' > /tmp/eval-record-3/.memplan/memory/aliases.mem && printf '' > /tmp/eval-record-3/.memplan/memory/facts.mem",
+      "expected_output": "aliases.mem still contains exactly one 'mp' entry (not duplicated). The set command replaces the existing key value. Checkpoint and session digest are written normally.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "alias-no-duplicate",
+          "text": ".memplan/memory/aliases.mem contains exactly one line starting with 'mp:' after the skill runs \u2014 the set command replaced the key rather than appending a second copy"
+        },
+        {
+          "id": "checkpoint-written",
+          "text": ".memplan/checkpoint.mem is updated with last-action and next-action entries"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Record the session. I note that all .plan.md files are read-only. That fact was already recorded last session under tag=plan-files.",
+      "description": "Fact dedup: an existing fact tag+text pair is restated. The grep-before-append guard must prevent a second identical entry in facts.mem.",
+      "setup": "mkdir -p /tmp/eval-record-4/.memplan/memory /tmp/eval-record-4/.memplan/decisions /tmp/eval-record-4/.memplan/sessions && echo '3/5 | integrate-tests' > /tmp/eval-record-4/.memplan/progress && touch /tmp/eval-record-4/.memplan/checkpoint.mem /tmp/eval-record-4/.memplan/hot.mem /tmp/eval-record-4/.memplan/budget.mem /tmp/eval-record-4/.memplan/memory/aliases.mem /tmp/eval-record-4/.memplan/memory/failures.mem && printf '+fact: tag=plan-files,text=.plan.md files are read-only\n' > /tmp/eval-record-4/.memplan/memory/facts.mem",
+      "expected_output": "facts.mem contains exactly one entry for tag=plan-files. The grep guard detected the existing entry and skipped the append. Checkpoint and session digest are written normally.",
+      "files": [],
+      "assertions": [
+        {
+          "id": "fact-no-duplicate",
+          "text": ".memplan/memory/facts.mem contains exactly one line with 'tag=plan-files' after the skill runs \u2014 the grep guard prevented a second append"
+        },
+        {
+          "id": "checkpoint-written",
+          "text": ".memplan/checkpoint.mem is updated with last-action and next-action entries"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Clarifies Phase 7 dedup logic in `memplan/record` SKILL.md: aliases use `set` (which replaces existing keys, making it inherently dedup-safe); facts use a `grep`-before-`append` guard to skip identical tag+text pairs
- Adds 2 new evals (ids 3 and 4) covering alias-dedup and fact-dedup scenarios to complement the existing eval 2 (basic alias+fact writing)
- Adds `version: "0.1.0"` to `plugins/memplan/.claude-plugin/plugin.json`

## Test plan

- [ ] Eval 2: alias written and fact appended to a fresh `.memplan` — both files updated
- [ ] Eval 3: alias key already exists — `set` replaces it, aliases.mem has exactly one entry for the key
- [ ] Eval 4: fact tag+text already in facts.mem — grep guard detects it and skips the append, facts.mem has exactly one matching entry

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)